### PR TITLE
ci: run wiki-cli tests on PRs and gate releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugins/ymir/wiki-cli
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - run: bun install --frozen-lockfile
+      - name: Typecheck
+        run: bun run typecheck
+      - name: Test
+        run: bun test
+      - name: Build
+        run: bun run build

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,11 @@ permissions:
   pull-requests: write
 
 jobs:
+  test:
+    uses: ./.github/workflows/ci.yml
+
   release-please:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` running typecheck, `bun test`, and build for `plugins/ymir/wiki-cli` on every pull request.
- Make `release-please` depend on the CI workflow (`workflow_call`) so releases on `main` are gated behind passing tests.

## Test plan
- [x] `bun install --frozen-lockfile` — 84 packages
- [x] `bun run typecheck` — exit 0
- [x] `bun test` — 38 pass / 0 fail
- [x] `bun run build` — bundles dist/cli.js
- [ ] CI runs green on this PR