### PR TITLE
docs: add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Ymir
 
+[![release-please](https://github.com/muitneliss/ymir/actions/workflows/release-please.yml/badge.svg)](https://github.com/muitneliss/ymir/actions/workflows/release-please.yml)
+[![release](https://img.shields.io/github/v/release/muitneliss/ymir?sort=semver)](https://github.com/muitneliss/ymir/releases)
+
 A Claude Code plugin marketplace + plugin that scaffolds the **mandatory project
 harness** every repo should start with — rules, lint, CI lint, wiki/context, and
 `CLAUDE.md`/`AGENT.md`.


### PR DESCRIPTION
## Summary
- Add release-please workflow status badge
- Add GitHub release/version badge (semver)

## Notes
- No LICENSE file present, so license badge omitted.