### PR TITLE
Dogfood: Ymir ingests its own docs + lightweight BM25 wiki query

### DIFF
--- a/.claude/hooks/block-wiki-edits.mjs
+++ b/.claude/hooks/block-wiki-edits.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
+const input = JSON.parse(readFileSync(0, "utf8"));
+const file = input?.tool_input?.file_path ?? "";
+
+const norm = file.replaceAll("\\", "/");
+
+const blocked =
+  /\/wiki\/sources\//.test(norm) ||
+  /\/wiki\/notes\//.test(norm) ||
+  /\/wiki\/index\.md$/.test(norm) ||
+  /\/wiki\/log\.md$/.test(norm);
+
+if (blocked) {
+  process.stdout.write(
+    JSON.stringify(
+      {
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason:
+            "Wiki docs are CLI-managed. Use the Ymir wiki CLI (ingest/note/index/log) instead of editing wiki files directly. Allowed direct edits: wiki/raw/** and wiki/SCHEMA.md.",
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}
+process.exit(0);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/.claude/hooks/block-wiki-edits.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+## Wiki / Context
+This project has an LLM-maintained wiki under `wiki/`. You MUST NOT hand-edit
+wiki docs (`wiki/sources`, `wiki/notes`, `index.md`, `log.md`) — they are
+managed by the Ymir wiki CLI and a PreToolUse hook blocks direct edits. See
+`wiki/SCHEMA.md` for the rules and command reference.

--- a/plugins/ymir/SKILL.md
+++ b/plugins/ymir/SKILL.md
@@ -71,8 +71,11 @@ If it errors, stop and report.
 Then tell the user the qmd one-time setup (also documented in `wiki/SCHEMA.md`):
 
 ```bash
-qmd collection add ./wiki --name <project>-wiki && qmd embed
+qmd collection add ./wiki --name <project>-wiki
 ```
+
+Search is keyword-only (BM25) — no `qmd embed`, no local LLM. Re-run
+`qmd collection add` after adding pages to refresh the index.
 
 **Design principle:** every change to the wiki harness goes through the wiki
 CLI. The skill must never copy templates, edit `.claude/settings.json`, or

--- a/plugins/ymir/wiki-cli/.gitignore
+++ b/plugins/ymir/wiki-cli/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+bin/

--- a/plugins/ymir/wiki-cli/src/commands/query.ts
+++ b/plugins/ymir/wiki-cli/src/commands/query.ts
@@ -23,5 +23,5 @@ export interface QueryInput {
 
 export async function runQuery(i: QueryInput): Promise<string> {
   const run = i.runner ?? defaultRunner;
-  return run("qmd", ["query", i.q, "--json", "--files"]);
+  return run("qmd", ["search", i.q, "--json", "--files"]);
 }

--- a/plugins/ymir/wiki-cli/src/templates/wiki/SCHEMA.md
+++ b/plugins/ymir/wiki-cli/src/templates/wiki/SCHEMA.md
@@ -42,8 +42,10 @@ One-time, on this machine:
 
 ```
 qmd collection add ./wiki --name PROJECT_NAME-wiki
-qmd embed
 ```
 
-Then `wiki query "..."` (which shells out to `qmd query --json --files`).
-Optional tighter integration: add a `qmd` MCP server (`qmd mcp`) to your client.
+Then `wiki query "..."` (which shells out to `qmd search --json --files`).
+Search is keyword-only (BM25) — lightweight, no embeddings and no local LLM, so
+there is no `qmd embed` step. Re-run `qmd collection add` after adding pages to
+refresh the index. Optional tighter integration: add a `qmd` MCP server
+(`qmd mcp`) to your client.

--- a/plugins/ymir/wiki-cli/test/query.test.ts
+++ b/plugins/ymir/wiki-cli/test/query.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "bun:test";
 import { runQuery } from "../src/commands/query.js";
 
 describe("runQuery", () => {
-  it("invokes qmd query with json/files flags and returns stdout", async () => {
+  it("invokes qmd search with json/files flags and returns stdout", async () => {
     const calls: { cmd: string; args: string[] }[] = [];
     const fakeRun = async (cmd: string, args: string[]) => {
       calls.push({ cmd, args });
@@ -10,7 +10,7 @@ describe("runQuery", () => {
     };
     const out = await runQuery({ root: "/w", q: "rate limit", runner: fakeRun });
     expect(calls[0]!.cmd).toBe("qmd");
-    expect(calls[0]!.args).toContain("query");
+    expect(calls[0]!.args).toContain("search");
     expect(calls[0]!.args).toContain("rate limit");
     expect(calls[0]!.args).toContain("--json");
     expect(calls[0]!.args).toContain("--files");

--- a/wiki/SCHEMA.md
+++ b/wiki/SCHEMA.md
@@ -1,0 +1,51 @@
+# Wiki Schema & Rules
+
+This wiki is an LLM-maintained knowledge base. **You (the LLM) never hand-write
+or hand-edit wiki documents.** All writes go through the Ymir wiki CLI, which
+formats and validates every change. Direct edits to `sources/`, `notes/`,
+`index.md`, and `log.md` are blocked by a PreToolUse hook.
+
+## Layers
+- `raw/` — immutable sources. You may read these; never edit them. The user adds files here.
+- `sources/` — one CLI-written summary page per ingested source.
+- `notes/` — CLI-written entity / concept / topic pages (the synthesis).
+- `index.md` — CLI-rebuilt catalog. Never edit by hand.
+- `log.md` — CLI-appended timeline. Never edit by hand.
+
+## The CLI
+Invoke via the bundled binary:
+
+```
+${CLAUDE_PLUGIN_ROOT}/wiki-cli/bin/wiki --root ./wiki <command>
+```
+
+Run `... help` for the full command reference. Key commands:
+- `ingest --raw <raw/path> --title <t>` (body on STDIN) — summarize a source.
+- `note --type entity|concept|topic --name <n>` (body on STDIN) — synthesis page.
+- `index` — rebuild the catalog.
+- `validate` — health check (frontmatter, `[[links]]`, orphans).
+- `query <q>` — search via qmd.
+
+## Page conventions
+- Cross-reference pages with `[[Exact Title]]`. The CLI validates every link target exists.
+- Frontmatter is injected by the CLI — do not write it yourself.
+
+## Operations
+- **Ingest:** user drops a file in `raw/` → you read it, discuss takeaways → call
+  `ingest` with the extracted body → then update related `notes` via `note`.
+- **Query:** call `query` → read returned pages → answer with citations →
+  optionally file the answer back as a `note`.
+- **Lint:** run `validate` → fix reported issues by issuing further CLI commands.
+
+## Search (qmd) setup
+One-time, on this machine:
+
+```
+qmd collection add ./wiki --name dogfood-wiki-wiki
+```
+
+Then `wiki query "..."` (which shells out to `qmd search --json --files`).
+Search is keyword-only (BM25) — lightweight, no embeddings and no local LLM, so
+there is no `qmd embed` step. Re-run `qmd collection add` after adding pages to
+refresh the index. Optional tighter integration: add a `qmd` MCP server
+(`qmd mcp`) to your client.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,0 +1,19 @@
+# Wiki Index
+
+## Sources
+
+- [Wiki CLI Publish Design Spec](sources/wiki-cli-publish-design-spec.md)
+- [Wiki CLI Publish Implementation Plan](sources/wiki-cli-publish-implementation-plan.md)
+- [Wiki Harness Design Spec](sources/wiki-harness-design-spec.md)
+- [Wiki Harness Implementation Plan](sources/wiki-harness-implementation-plan.md)
+- [Wiki Schema](sources/wiki-schema.md)
+- [Ymir README](sources/ymir-readme.md)
+- [Ymir SKILL Dispatcher](sources/ymir-skill-dispatcher.md)
+
+## Notes
+
+- [Init Scaffold Contract](notes/init-scaffold-contract.md)
+- [Publish and Auto-Fetch Flow](notes/publish-and-auto-fetch-flow.md)
+- [Wiki CLI Command Surface](notes/wiki-cli-command-surface.md)
+- [Wiki Harness Model](notes/wiki-harness-model.md)
+

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,0 +1,15 @@
+# Wiki Log
+
+## [2026-06-17] ingest | Ymir README
+## [2026-06-17] ingest | Ymir SKILL Dispatcher
+## [2026-06-17] ingest | Wiki Harness Design Spec
+## [2026-06-17] ingest | Wiki CLI Publish Design Spec
+## [2026-06-17] ingest | Wiki Harness Implementation Plan
+## [2026-06-17] ingest | Wiki CLI Publish Implementation Plan
+## [2026-06-17] ingest | Wiki Schema
+## [2026-06-17] note | Wiki Harness Model
+## [2026-06-17] note | Wiki CLI Command Surface
+## [2026-06-17] note | Publish and Auto-Fetch Flow
+## [2026-06-17] note | Init Scaffold Contract
+## [2026-06-17] note | Wiki Harness Model
+## [2026-06-17] ingest | Wiki Schema

--- a/wiki/notes/init-scaffold-contract.md
+++ b/wiki/notes/init-scaffold-contract.md
@@ -1,0 +1,15 @@
+---
+title: Init Scaffold Contract
+type: concept
+date: 2026-06-17
+tags: []
+source_count: 0
+---
+
+# Init Scaffold Contract
+
+`wiki init` is the single idempotent CLI call that lays down the entire wiki harness into a project — the SKILL must never copy templates or edit settings/CLAUDE.md by hand. On success its last line is `wiki valid`; if it errors, the caller stops and reports.
+
+What it creates (write-if-missing, so re-runs are safe): the wiki tree `raw/`, `sources/`, `notes/` (each with `.gitkeep`), `SCHEMA.md` (with PROJECT\_NAME rendered to the project basename), seeded `index.md` and `log.md`. It also installs the PreToolUse hook `.claude/hooks/block-wiki-edits.mjs`, merges a hook entry into `.claude/settings.json` (merge, never clobber), and appends the wiki pointer block to `CLAUDE.md`. Finally it runs `validate` and reports created/skipped paths plus whether settings were merged and the CLAUDE.md block appended.
+
+The hook denies direct Write/Edit/MultiEdit on `wiki/sources/`, `wiki/notes/`, `wiki/index.md`, and `wiki/log.md`, while allowing `wiki/raw/**` and `wiki/SCHEMA.md`. This is the scaffold half of the harness: it establishes the structure and enforcement, after which [[Wiki Schema]] plus the CLI drive ingest/query/lint. See [[Ymir SKILL Dispatcher]] for how the dispatcher invokes it, [[Wiki CLI Command Surface]] for the command, and [[Wiki Harness Model]] for the model.

--- a/wiki/notes/publish-and-auto-fetch-flow.md
+++ b/wiki/notes/publish-and-auto-fetch-flow.md
@@ -1,0 +1,15 @@
+---
+title: Publish and Auto-Fetch Flow
+type: concept
+date: 2026-06-17
+tags: []
+source_count: 0
+---
+
+# Publish and Auto-Fetch Flow
+
+How the wiki CLI reaches user machines as a ready-to-run binary with no manual install and no Node runtime dependency. Hard requirement: fail fast, no fallback — runtime never touches `dist/cli.js` (it is gitignored and unshipped); any failure is loud stderr + nonzero exit.
+
+Publish side: a CI `compile` job, gated on release-please cutting a release, cross-compiles four `bun --compile` targets into assets `wiki-darwin-arm64`, `wiki-darwin-x64`, `wiki-linux-x64`, `wiki-linux-arm64`, generates `SHA256SUMS.txt`, and `gh release upload`s them to the tag.
+
+Fetch side: the SessionStart hook `ensure-wiki-binary.mjs` runs every session. It reads the expected version from `plugin.json $.version` (release-please keeps this synced — not the independent `wiki-cli/package.json`). If `bin/wiki` exists and `bin/.version` matches, it no-ops. Otherwise it detects the platform via `uname -sm` (pure, unit-tested `detectAssetLabel` in `src/platform.ts`), curls the matching asset + `SHA256SUMS.txt`, verifies sha256, and on success installs `bin/wiki` (chmod 0755) and stamps `.version`; on mismatch or network failure it errors and exits non-zero. See [[Wiki CLI Publish Design Spec]] and [[Wiki CLI Publish Implementation Plan]] for the full design, [[Wiki CLI Command Surface]] for what the binary exposes, and [[Wiki Harness Model]] for the larger picture.

--- a/wiki/notes/wiki-cli-command-surface.md
+++ b/wiki/notes/wiki-cli-command-surface.md
@@ -1,0 +1,15 @@
+---
+title: Wiki CLI Command Surface
+type: concept
+date: 2026-06-17
+tags: []
+source_count: 0
+---
+
+# Wiki CLI Command Surface
+
+The wiki CLI (`plugins/ymir/wiki-cli`, TypeScript/Node, built and tested with bun) is the only sanctioned writer of the wiki. It is invoked as `wiki --root ./wiki <command>` and built on commander (parsing/help), a small js-yaml frontmatter module, remark (format), and zod (per-page-type frontmatter schema).
+
+Commands: `init` scaffolds the wiki tree + hook + settings + CLAUDE.md block and validates; `ingest --raw <path> --title <t>` (body on stdin) writes a source summary; `note --type entity|concept|topic --name <n>` (body on stdin) writes a synthesis page; `index` rebuilds `index.md`; `log <op> <title>` appends to `log.md`; `validate` checks frontmatter schema, broken double-bracket links, and orphan notes; `fmt` normalizes markdown; `query <q>` shells out to qmd; `help` prints the contract for the LLM.
+
+Invariant: every write command runs format then validate before committing — on failure it aborts with a nonzero exit and an actionable message, leaving no partial file, and rebuilds index + appends log atomically on success. Frontmatter is injected by the CLI (never hand-written): common title/type/date/tags, plus source/ingested for source pages and source\_count for notes. See [[Wiki Harness Design Spec]] and [[Wiki Harness Implementation Plan]] for origin, [[Wiki Schema]] for the workflow rules, and [[Wiki Harness Model]] for the surrounding model.

--- a/wiki/notes/wiki-harness-model.md
+++ b/wiki/notes/wiki-harness-model.md
@@ -1,0 +1,17 @@
+---
+title: Wiki Harness Model
+type: concept
+date: 2026-06-17
+tags: []
+source_count: 0
+---
+
+# Wiki Harness Model
+
+The wiki harness is Ymir's "wiki / context" concern: a generic, domain-agnostic, LLM-maintained markdown knowledge base scaffolded into a target project. It replaces query-time RAG over raw documents with a persistent, interlinked wiki the LLM grows over time.
+
+Three layers. **Raw** (`wiki/raw/`) holds immutable source documents the LLM reads but never edits; the user drops files here. **Wiki** (`sources/`, `notes/`, `index.md`, `log.md`) is LLM-owned but written exclusively through the CLI: `sources/` are one-per-document summaries, `notes/` are entity/concept/topic synthesis, `index.md` is the rebuilt catalog, `log.md` the appended timeline. **Schema** (`wiki/SCHEMA.md`) is the rules document telling the LLM how the wiki is structured and which workflows (ingest / query / lint) to follow.
+
+Two enforcement layers keep it deterministic: the CLI formats then validates every write (rejecting invalid input so the LLM must fix it), and a PreToolUse hook hard-blocks any direct Write/Edit/MultiEdit on wiki content paths. Read/search is delegated to qmd. See [[Wiki Harness Design Spec]] for the full design, [[Wiki Schema]] for the rules contract, and [[Ymir README]] / [[Ymir SKILL Dispatcher]] for how Ymir scaffolds it.
+
+The model is realized by four moving parts: the [[Init Scaffold Contract]] lays the tree, hook, settings, and CLAUDE.md block; the [[Wiki CLI Command Surface]] is the only sanctioned writer; and the [[Publish and Auto-Fetch Flow]] delivers that CLI as a verified per-platform binary.

--- a/wiki/raw/README.md
+++ b/wiki/raw/README.md
@@ -1,0 +1,54 @@
+# Ymir
+
+[![release-please](https://github.com/muitneliss/ymir/actions/workflows/release-please.yml/badge.svg)](https://github.com/muitneliss/ymir/actions/workflows/release-please.yml)
+[![release](https://img.shields.io/github/v/release/muitneliss/ymir?sort=semver)](https://github.com/muitneliss/ymir/releases)
+
+A Claude Code plugin marketplace + plugin that scaffolds the **mandatory project
+harness** every repo should start with — rules, lint, CI lint, wiki/context, and
+`CLAUDE.md`/`AGENT.md`.
+
+Ymir does **not** generate application code. It interviews you about your
+techstack (Go vs TypeScript, frontend vs backend, …) and builds only the
+skeleton. You then drive the actual development through Claude Code, guided by the
+harness Ymir laid down.
+
+## Layout
+
+```
+ymir/
+├── .claude-plugin/
+│   └── marketplace.json        # the "ymir" marketplace
+└── plugins/
+    └── ymir/                   # the "ymir" plugin
+        ├── .claude-plugin/
+        │   └── plugin.json
+        └── SKILL.md            # single dispatcher skill → /ymir
+```
+
+Ymir is one skill, not a fixed command list. Whatever you type after `ymir` is
+the intent; the skill interprets it and acts on the current project:
+
+```
+ymir init for this project
+ymir add lint for this project
+ymir add rules
+ymir set up CI
+```
+
+## Try it locally
+
+```shell
+/plugin marketplace add ./
+/plugin install ymir@ymir
+/reload-plugins
+```
+
+Then: `/ymir init for this project`
+
+## Status
+
+`v0.2.0`. The **wiki / context** harness piece is implemented: `/ymir add
+context` scaffolds an LLM-maintained `wiki/` (backed by the bundled wiki CLI in
+`plugins/ymir/wiki-cli`), installs a PreToolUse hook that blocks hand-editing
+wiki docs, and wires in `qmd` for search. The socratic interview and the other
+harness pieces (lint, CI, rules) are still stubbed.

--- a/wiki/raw/SCHEMA.md
+++ b/wiki/raw/SCHEMA.md
@@ -1,0 +1,51 @@
+# Wiki Schema & Rules
+
+This wiki is an LLM-maintained knowledge base. **You (the LLM) never hand-write
+or hand-edit wiki documents.** All writes go through the Ymir wiki CLI, which
+formats and validates every change. Direct edits to `sources/`, `notes/`,
+`index.md`, and `log.md` are blocked by a PreToolUse hook.
+
+## Layers
+- `raw/` — immutable sources. You may read these; never edit them. The user adds files here.
+- `sources/` — one CLI-written summary page per ingested source.
+- `notes/` — CLI-written entity / concept / topic pages (the synthesis).
+- `index.md` — CLI-rebuilt catalog. Never edit by hand.
+- `log.md` — CLI-appended timeline. Never edit by hand.
+
+## The CLI
+Invoke via the bundled binary:
+
+```
+${CLAUDE_PLUGIN_ROOT}/wiki-cli/bin/wiki --root ./wiki <command>
+```
+
+Run `... help` for the full command reference. Key commands:
+- `ingest --raw <raw/path> --title <t>` (body on STDIN) — summarize a source.
+- `note --type entity|concept|topic --name <n>` (body on STDIN) — synthesis page.
+- `index` — rebuild the catalog.
+- `validate` — health check (frontmatter, `[[links]]`, orphans).
+- `query <q>` — search via qmd.
+
+## Page conventions
+- Cross-reference pages with `[[Exact Title]]`. The CLI validates every link target exists.
+- Frontmatter is injected by the CLI — do not write it yourself.
+
+## Operations
+- **Ingest:** user drops a file in `raw/` → you read it, discuss takeaways → call
+  `ingest` with the extracted body → then update related `notes` via `note`.
+- **Query:** call `query` → read returned pages → answer with citations →
+  optionally file the answer back as a `note`.
+- **Lint:** run `validate` → fix reported issues by issuing further CLI commands.
+
+## Search (qmd) setup
+One-time, on this machine:
+
+```
+qmd collection add ./wiki --name dogfood-wiki-wiki
+```
+
+Then `wiki query "..."` (which shells out to `qmd search --json --files`).
+Search is keyword-only (BM25) — lightweight, no embeddings and no local LLM, so
+there is no `qmd embed` step. Re-run `qmd collection add` after adding pages to
+refresh the index. Optional tighter integration: add a `qmd` MCP server
+(`qmd mcp`) to your client.

--- a/wiki/raw/SKILL.md
+++ b/wiki/raw/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: ymir
+description: Ymir scaffolds a project's harness skeleton for THIS project (the current working directory) — rules, lint, CI lint, wiki/context, and CLAUDE.md/AGENT.md. Use whenever the user asks Ymir to do something to the project, e.g. "ymir init for this project", "ymir add lint for this project", "ymir add rules", "ymir set up CI", "scaffold the harness", "bootstrap this repo". Interviews the user about their techstack and builds only the skeleton — never application code.
+argument-hint: "init | add lint | add rules | add ci | add context | add claude.md — what to do for this project"
+---
+
+# Ymir
+
+Ymir builds the **harness skeleton** for the current project — never application
+code. The user drives all real coding through Claude Code; Ymir only lays down
+the foundation that steers it:
+
+1. **rules** — coding standards / conventions
+2. **lint** — linter config for the chosen stack
+3. **CI lint** — a CI workflow that runs the linter
+4. **wiki / context** — a place for project knowledge
+5. **CLAUDE.md / AGENT.md** — the file that steers Claude Code on this repo
+
+## How this skill works
+
+This is a single dispatcher. The user's words after `ymir` are the intent
+(`$ARGUMENTS`) — interpret them and act on **this project** (the current working
+directory). There is no fixed command list; map the intent to one of the harness
+concerns above. Examples:
+
+| User says | Intent |
+|---|---|
+| `ymir init for this project` | run the full flow: interview, then scaffold every harness piece that fits the stack |
+| `ymir add lint for this project` | add just the linter config (+ wire it into CI if CI exists) |
+| `ymir add rules` | add/extend the rules file |
+| `ymir set up CI` | add the CI lint workflow |
+| anything ambiguous | ask a short clarifying question, then proceed |
+
+If `$ARGUMENTS` is empty, treat it as `init`.
+
+## Step 1 — Know the stack (socratic interview)
+
+The user does not hand-write code, so Ymir cannot infer the stack from existing
+files alone. Ask, one decision at a time (AskUserQuestion), only what the
+requested action needs:
+
+- **Language**: Go, TypeScript, … (drives linter + CI choice)
+- **Layer**: frontend, backend, or both
+- (more questions are added as the harness templates mature)
+
+For a narrow action (e.g. `add lint`) ask only the questions that action needs;
+for `init`, gather the full picture up front.
+
+## Step 2 — Scaffold
+
+Map the intent to a harness concern and scaffold it into the current project
+(cwd). Other concerns (lint, CI, rules, CLAUDE.md) are still stubbed; the
+**wiki / context** concern is implemented below.
+
+### wiki / context
+
+Triggered by intents like `ymir add context`, `ymir add wiki`, or as part of
+`ymir init`. The wiki harness is scaffolded by **a single CLI call** — never by
+hand-editing files. The CLI owns the tree, the hook, the `.claude/settings.json`
+entry, the `CLAUDE.md` block, and the validation step.
+
+From the project root, run:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/wiki-cli/bin/wiki" --root ./wiki init
+```
+
+It is idempotent — safe to re-run. On success the last line is `wiki valid`.
+If it errors, stop and report.
+
+Then tell the user the qmd one-time setup (also documented in `wiki/SCHEMA.md`):
+
+```bash
+qmd collection add ./wiki --name <project>-wiki && qmd embed
+```
+
+**Design principle:** every change to the wiki harness goes through the wiki
+CLI. The skill must never copy templates, edit `.claude/settings.json`, or
+append to `CLAUDE.md` directly.
+
+Never write application code; only the harness skeleton above.
+
+## Boundaries
+
+- Operate on the current project only ("this project" = cwd).
+- Build only the skeleton — never generate application/business code.
+- Prefer asking over assuming; the interview is the source of truth.

--- a/wiki/raw/wiki-cli-publish-design.md
+++ b/wiki/raw/wiki-cli-publish-design.md
@@ -1,0 +1,198 @@
+# Wiki CLI: GitHub Release binaries + auto-fetch on plugin use
+
+Date: 2026-06-17
+Status: approved (design)
+Branch: `feat/wiki-cli-publish`
+
+## Problem
+
+The Ymir wiki CLI (`plugins/ymir/wiki-cli`, `@ymir/wiki-cli`) is run by the
+ymir SKILL via `node ${CLAUDE_PLUGIN_ROOT}/wiki-cli/dist/cli.js`. We want users
+who install the Claude plugin to get a standalone, ready-to-run binary
+automatically, with no manual install step and no Node dependency at runtime.
+
+## Goals
+
+- Compile standalone single-file binaries on each release and publish them as
+  GitHub Release assets.
+- When the plugin is used, automatically fetch the matching-platform binary
+  from the GitHub Release into a cached location.
+- The LLM drives the wiki exclusively through this binary.
+
+## Non-goals (YAGNI)
+
+- No Windows target.
+- No npm / GitHub Packages publishing.
+- No self-update beyond a version-stamp check.
+- No code signing beyond sha256 checksums.
+
+## Hard requirement: fail fast, no fallback
+
+There is **no `node dist/cli.js` fallback**. Runtime never touches `dist`.
+
+- If the SessionStart hook cannot download or verify the binary, it writes a
+  loud error to stderr and exits non-zero. No silent no-op.
+- If the SKILL is asked to run the wiki CLI and the binary is absent, it stops
+  with an explicit error ("wiki binary not installed — SessionStart hook
+  failed, see log") and does not attempt any other execution path.
+- `dist/cli.js` is no longer shipped or committed in the plugin (gitignored).
+  The `build` script remains only as input to the `compile` step.
+
+## Platforms / asset naming
+
+Four `bun --compile` targets, asset label per platform:
+
+| bun target          | asset name          | uname -sm        |
+|---------------------|---------------------|------------------|
+| bun-darwin-arm64    | `wiki-darwin-arm64` | `Darwin arm64`   |
+| bun-darwin-x64      | `wiki-darwin-x64`   | `Darwin x86_64`  |
+| bun-linux-x64       | `wiki-linux-x64`    | `Linux x86_64`   |
+| bun-linux-aarch64   | `wiki-linux-arm64`  | `Linux aarch64` / `Linux arm64` |
+
+Plus `SHA256SUMS.txt` covering all four assets.
+
+## Architecture — publish & auto-fetch
+
+```mermaid
+flowchart TD
+    subgraph CI["GitHub Actions (on release tag)"]
+        RP["release-please cuts tag vX.Y.Z"] --> CMP["compile job\nbun build --compile (4 targets)"]
+        CMP --> A["wiki-darwin-arm64 / -x64\nwiki-linux-x64 / -arm64"]
+        CMP --> SUM["SHA256SUMS.txt"]
+        A & SUM --> REL["gh release upload to tag"]
+    end
+
+    subgraph User["User machine (Claude Code)"]
+        SS["SessionStart hook\nensure-wiki-binary.mjs"] --> CK{"bin present\n& version matches?"}
+        CK -- yes --> DONE["ready"]
+        CK -- no --> DET["detect os/arch (uname -sm)"]
+        DET --> DL["curl -L release asset + SHA256SUMS"]
+        DL --> VRF{"sha256 ok?"}
+        VRF -- yes --> INST["install wiki-cli/bin/wiki\nchmod +x, write .version"]
+        VRF -- no --> ERR["stderr error + exit 1\n(NO fallback)"]
+        DL -- network fail --> ERR
+        INST --> DONE
+    end
+    REL -.download.-> DL
+```
+
+## Architecture — how the LLM uses the CLI
+
+```mermaid
+flowchart LR
+    LLM["Claude (ymir SKILL)"] -->|spawn| BIN["wiki-cli/bin/wiki"]
+    BIN -->|--root ./wiki| W[("wiki/ dir")]
+    LLM -.stdin body.-> BIN
+
+    subgraph CMDS["commands"]
+        I["ingest --raw --title"]
+        N["note --type --name"]
+        Q["query <q>"]
+        IX["index"]
+        V["validate"]
+        L["log <op> <title>"]
+        F["fmt"]
+    end
+    BIN --- CMDS
+
+    HOOK["PreToolUse hook\nblock-wiki-edits.mjs"]
+    LLM -. "Edit/Write on wiki/* → BLOCKED" .-> HOOK
+    HOOK -.protects.-> W
+```
+
+LLM contract: never hand-edit `wiki/`. Pipe content to `wiki ingest` /
+`wiki note` via stdin; read back with `wiki query`; keep `index.md` / `log.md`
+fresh via `index` / `log`; gate with `validate`. The PreToolUse hook blocks raw
+edits to `wiki/` so the CLI is the only writer.
+
+## Components
+
+### 1. `compile` CI job (`.github/workflows/release-please.yml`)
+- `needs: release-please`, guarded by
+  `if: needs.release-please.outputs.release_created == 'true'`.
+- `runs-on: ubuntu-latest`, `working-directory: plugins/ymir/wiki-cli`.
+- `oven-sh/setup-bun@v2` (bun 1.3.14), `bun install --frozen-lockfile`.
+- Matrix or sequential over 4 targets:
+  `bun build ./src/cli.ts --compile --target=<t> --outfile dist/wiki-<label>`.
+- `sha256sum dist/wiki-* > dist/SHA256SUMS.txt`.
+- `gh release upload <tag> dist/wiki-* dist/SHA256SUMS.txt`
+  (`tag` = `needs.release-please.outputs.tag_name`,
+  `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`).
+
+### 2. Target-detection module (`src/platform.ts`)
+- Pure function `assetLabel(unameS: string, unameM: string): string` mapping to
+  one of the four labels; throws on unsupported platform with a clear message.
+- Unit-tested. Imported by the hook so logic is testable without network.
+
+### 3. SessionStart hook (`templates/hooks/ensure-wiki-binary.mjs`)
+- Resolve `${CLAUDE_PLUGIN_ROOT}`; target dir `wiki-cli/bin/`.
+- Read expected version from `.claude-plugin/plugin.json` `$.version` — this is
+  the field release-please keeps in sync with the release tag. Do NOT use
+  `wiki-cli/package.json` (independent, drifts).
+- If `bin/wiki` exists and `bin/.version` == expected → exit 0.
+- Else detect platform via `uname -sm`, build asset URL:
+  `https://github.com/<owner>/<repo>/releases/download/v<version>/wiki-<label>`.
+- `curl -fL` asset + `SHA256SUMS.txt`; verify sha256 of the downloaded asset
+  against the sums file. On mismatch or any curl failure → `console.error` a
+  loud message and `process.exit(1)`.
+- On success: write to `bin/wiki`, `chmod 0o755`, write `bin/.version`.
+- Wire into the hooks the SKILL installs (extend
+  `templates/hooks/settings.snippet.json` with a `SessionStart` entry).
+
+### 4. SKILL / plugin wiring (`plugins/ymir/SKILL.md`)
+- Replace `node ${CLAUDE_PLUGIN_ROOT}/wiki-cli/dist/cli.js` with
+  `${CLAUDE_PLUGIN_ROOT}/wiki-cli/bin/wiki`.
+- Document: if the binary is missing, stop and report the SessionStart failure;
+  do not run any fallback.
+
+### 5. Packaging cleanup (`plugins/ymir/wiki-cli`)
+- Add `"compile"` script to `package.json`.
+- `.gitignore` `dist/`; remove tracked `dist/cli.js`.
+
+## Data flow
+
+1. Release tag → CI compiles 4 binaries + sums → assets on the Release.
+2. First Claude session after install → SessionStart hook detects platform,
+   downloads + verifies the matching binary into `wiki-cli/bin/wiki`, stamps
+   version. Subsequent sessions: stamp matches → no-op.
+3. SKILL runs `wiki-cli/bin/wiki --root ./wiki <cmd>` for all wiki operations.
+
+## Error handling
+
+| Failure | Behavior |
+|---------|----------|
+| Unsupported platform | hook: `assetLabel` throws clear msg → exit 1 |
+| Download fails (network/404) | hook: stderr error → exit 1 |
+| sha256 mismatch | hook: stderr error, do not install → exit 1 |
+| Binary missing at SKILL run | SKILL stops, reports hook failure, no fallback |
+
+## Testing
+
+- `src/platform.ts`: unit tests for all four mappings + unsupported-platform
+  throw (`bun test`).
+- `compile` CI job is the integration check (all 4 targets build).
+- Manual: run a compiled binary `./dist/wiki-<label> --root ./wiki validate`
+  → prints `wiki valid`.
+
+## Version source
+
+- Single source of truth = `plugins/ymir/.claude-plugin/plugin.json` `$.version`,
+  which release-please updates (via `extra-files`) to match each release tag.
+- Asset URL tag = `v<that version>`. Hook stamp compares against the same value.
+- `wiki-cli/package.json` version is independent and MUST NOT be used for the
+  tag or stamp.
+
+## Open dependencies
+
+- `<owner>/<repo>` = `muitneliss/ymir`.
+- release-please: root package `.`, `release-type: simple`, `package-name: ymir`.
+  Tag format = `v<version>` (single root package, no component prefix). Confirm
+  on first release; the `compile` job reads `needs.release-please.outputs.tag_name`
+  rather than constructing it.
+
+## Pre-existing issue (out of scope, flagged)
+
+`.release-please-manifest.json` and `version.txt` are at `0.1.0` while
+`plugin.json` and `wiki-cli/package.json` are at `0.2.0`. This drift predates
+this work. It affects what the next release tag will be (computed from `0.1.0`).
+Not fixed here — flagged for the user to decide.

--- a/wiki/raw/wiki-cli-publish-plan.md
+++ b/wiki/raw/wiki-cli-publish-plan.md
@@ -1,0 +1,636 @@
+# Wiki CLI: GitHub Release binaries + auto-fetch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Compile standalone wiki CLI binaries on every release, publish them as GitHub Release assets, and auto-download the matching-platform binary into the plugin on first session use — no fallback, fail loud.
+
+**Architecture:** CI `compile` job (triggered by release-please) cross-compiles 4 platform binaries with `bun --compile`, attaches them + SHA256SUMS.txt to the GitHub Release. A plugin-level `SessionStart` hook (`hooks/ensure-wiki-binary.mjs`) checks for the binary on every session start, downloads and sha256-verifies it on first use or version change, exits 2 on any failure (no fallback). The SKILL calls the binary directly; `dist/` is gitignored.
+
+**Tech Stack:** Bun 1.3.14, TypeScript, Node.js (for hook script), GitHub Actions (`googleapis/release-please-action@v4`, `oven-sh/setup-bun@v2`), `curl` + `sha256sum` (Linux/macOS standard tools).
+
+**Branch:** `feat/wiki-cli-publish` — worktree at `.worktrees/wiki-publish`.  
+**Merge order:** merge PR#3 (`feat/ci-test-step`) before this branch. It adds a `test` job that gates `release-please`; when this branch is rebased on the result, `compile` chains as `test → release-please → compile`.
+
+---
+
+## File Map
+
+| Path | Action | Responsibility |
+|------|--------|----------------|
+| `plugins/ymir/wiki-cli/src/platform.ts` | CREATE | `detectAssetLabel(unameSM: string): string` — pure fn, tested |
+| `plugins/ymir/wiki-cli/test/platform.test.ts` | CREATE | Unit tests for `detectAssetLabel` |
+| `plugins/ymir/hooks/ensure-wiki-binary.mjs` | CREATE | SessionStart hook — download, verify, install binary |
+| `plugins/ymir/hooks/hooks.json` | CREATE | Plugin hook config wiring `ensure-wiki-binary.mjs` to `SessionStart` |
+| `.github/workflows/release-please.yml` | MODIFY | Add `outputs` to release-please job + add `compile` job |
+| `plugins/ymir/wiki-cli/package.json` | MODIFY | Add `compile:*` scripts for local use |
+| `plugins/ymir/wiki-cli/.gitignore` | MODIFY | Add `dist/` |
+| `plugins/ymir/SKILL.md` | MODIFY | Line 87: replace `node .../dist/cli.js` → `.../bin/wiki` |
+| `plugins/ymir/templates/wiki/SCHEMA.md` | MODIFY | Line 19: same replacement |
+
+---
+
+## Task 1: `src/platform.ts` — platform detection (TDD)
+
+**Files:**
+- Create: `plugins/ymir/wiki-cli/src/platform.ts`
+- Create: `plugins/ymir/wiki-cli/test/platform.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `plugins/ymir/wiki-cli/test/platform.test.ts`:
+
+```typescript
+import { expect, test } from "bun:test";
+import { detectAssetLabel } from "../src/platform.js";
+
+test("darwin arm64", () => {
+  expect(detectAssetLabel("Darwin arm64")).toBe("darwin-arm64");
+});
+test("darwin x64", () => {
+  expect(detectAssetLabel("Darwin x86_64")).toBe("darwin-x64");
+});
+test("linux x64", () => {
+  expect(detectAssetLabel("Linux x86_64")).toBe("linux-x64");
+});
+test("linux aarch64", () => {
+  expect(detectAssetLabel("Linux aarch64")).toBe("linux-arm64");
+});
+test("linux arm64 (alternate uname output)", () => {
+  expect(detectAssetLabel("Linux arm64")).toBe("linux-arm64");
+});
+test("trims surrounding whitespace", () => {
+  expect(detectAssetLabel("  Darwin arm64  ")).toBe("darwin-arm64");
+});
+test("unsupported platform throws with message", () => {
+  expect(() => detectAssetLabel("Windows x86_64")).toThrow("Unsupported platform");
+});
+```
+
+- [ ] **Step 2: Run — expect import error**
+
+```bash
+cd plugins/ymir/wiki-cli && bun test test/platform.test.ts
+```
+
+Expected: `error: Cannot find module "../src/platform.js"`
+
+- [ ] **Step 3: Create `src/platform.ts`**
+
+```typescript
+export function detectAssetLabel(unameSM: string): string {
+  const s = unameSM.trim();
+  if (s === "Darwin arm64")                          return "darwin-arm64";
+  if (s === "Darwin x86_64")                         return "darwin-x64";
+  if (s === "Linux x86_64")                          return "linux-x64";
+  if (s === "Linux aarch64" || s === "Linux arm64")  return "linux-arm64";
+  throw new Error(
+    `Unsupported platform: "${s}". Supported: Darwin/Linux × arm64/x86_64.`
+  );
+}
+```
+
+- [ ] **Step 4: Run — expect 7 pass**
+
+```bash
+cd plugins/ymir/wiki-cli && bun test test/platform.test.ts
+```
+
+Expected: `7 pass  0 fail`
+
+- [ ] **Step 5: Run full test suite — no regressions**
+
+```bash
+cd plugins/ymir/wiki-cli && bun test
+```
+
+Expected: `45 pass  0 fail  ` (38 existing + 7 new)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/ymir/wiki-cli/src/platform.ts plugins/ymir/wiki-cli/test/platform.test.ts
+git commit -m "feat(wiki-cli): add detectAssetLabel for cross-platform binary fetch"
+```
+
+---
+
+## Task 2: `hooks/ensure-wiki-binary.mjs` — download/verify/install
+
+**Files:**
+- Create: `plugins/ymir/hooks/ensure-wiki-binary.mjs`
+
+- [ ] **Step 1: Create hook script**
+
+Create `plugins/ymir/hooks/ensure-wiki-binary.mjs`:
+
+```javascript
+#!/usr/bin/env node
+import { execSync, spawnSync } from "node:child_process";
+import {
+  chmodSync, existsSync, mkdirSync,
+  readFileSync, renameSync, unlinkSync, writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+
+function detectAssetLabel(unameSM) {
+  const s = unameSM.trim();
+  if (s === "Darwin arm64")                         return "darwin-arm64";
+  if (s === "Darwin x86_64")                        return "darwin-x64";
+  if (s === "Linux x86_64")                         return "linux-x64";
+  if (s === "Linux aarch64" || s === "Linux arm64") return "linux-arm64";
+  throw new Error(`Unsupported platform: "${s}". Supported: Darwin/Linux × arm64/x86_64.`);
+}
+
+const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT;
+if (!PLUGIN_ROOT) {
+  process.stderr.write("[ymir] CLAUDE_PLUGIN_ROOT not set — cannot ensure wiki binary\n");
+  process.exit(2);
+}
+
+let pluginVersion;
+try {
+  const manifest = JSON.parse(
+    readFileSync(join(PLUGIN_ROOT, ".claude-plugin/plugin.json"), "utf8")
+  );
+  pluginVersion = manifest.version;
+} catch (e) {
+  process.stderr.write(`[ymir] Cannot read plugin.json: ${e.message}\n`);
+  process.exit(2);
+}
+
+const binDir    = join(PLUGIN_ROOT, "wiki-cli/bin");
+const binPath   = join(binDir, "wiki");
+const stampPath = join(binDir, ".version");
+
+// Fast path: already installed and version matches
+if (existsSync(binPath) && existsSync(stampPath)) {
+  if (readFileSync(stampPath, "utf8").trim() === pluginVersion) process.exit(0);
+}
+
+// Detect platform
+let label;
+try {
+  const uname = execSync("uname -sm", { encoding: "utf8" });
+  label = detectAssetLabel(uname);
+} catch (e) {
+  process.stderr.write(`[ymir] Platform detection failed: ${e.message}\n`);
+  process.exit(2);
+}
+
+const base     = `https://github.com/muitneliss/ymir/releases/download/v${pluginVersion}`;
+const assetUrl = `${base}/wiki-${label}`;
+const sumsUrl  = `${base}/SHA256SUMS.txt`;
+
+mkdirSync(binDir, { recursive: true });
+
+const tmpBin  = `${binPath}.tmp`;
+const tmpSums = join(binDir, "SHA256SUMS.txt.tmp");
+
+// Download binary
+const dlBin = spawnSync("curl", ["-fsSL", "--output", tmpBin, assetUrl], { stdio: "inherit" });
+if (dlBin.status !== 0) {
+  process.stderr.write(`[ymir] Failed to download wiki binary: ${assetUrl}\n`);
+  process.exit(2);
+}
+
+// Download checksum file
+const dlSums = spawnSync("curl", ["-fsSL", "--output", tmpSums, sumsUrl], { stdio: "inherit" });
+if (dlSums.status !== 0) {
+  process.stderr.write(`[ymir] Failed to download SHA256SUMS: ${sumsUrl}\n`);
+  process.exit(2);
+}
+
+// Verify sha256
+const sumsText     = readFileSync(tmpSums, "utf8");
+const expectedLine = sumsText.split("\n").find((l) => l.includes(`wiki-${label}`));
+if (!expectedLine) {
+  process.stderr.write(`[ymir] No sha256 entry for wiki-${label} in SHA256SUMS.txt\n`);
+  process.exit(2);
+}
+const expectedHash = expectedLine.trim().split(/\s+/)[0];
+const actualHash   = createHash("sha256").update(readFileSync(tmpBin)).digest("hex");
+if (actualHash !== expectedHash) {
+  process.stderr.write(
+    `[ymir] SHA256 mismatch for wiki-${label}:\n  expected ${expectedHash}\n  got      ${actualHash}\n`
+  );
+  process.exit(2);
+}
+
+// Install
+renameSync(tmpBin, binPath);
+chmodSync(binPath, 0o755);
+writeFileSync(stampPath, pluginVersion);
+try { unlinkSync(tmpSums); } catch { /* ignore cleanup failure */ }
+
+process.stdout.write(`[ymir] Installed wiki binary v${pluginVersion} (${label})\n`);
+```
+
+- [ ] **Step 2: Smoke-test fast path (no network)**
+
+Simulate the fast path by calling the script with a fake env where binary + matching stamp already exist:
+
+```bash
+mkdir -p /tmp/ymir-test-plugin/wiki-cli/bin
+echo "0.2.0" > /tmp/ymir-test-plugin/wiki-cli/bin/.version
+touch /tmp/ymir-test-plugin/wiki-cli/bin/wiki
+# Create minimal plugin.json
+mkdir -p /tmp/ymir-test-plugin/.claude-plugin
+echo '{"version":"0.2.0"}' > /tmp/ymir-test-plugin/.claude-plugin/plugin.json
+
+CLAUDE_PLUGIN_ROOT=/tmp/ymir-test-plugin node plugins/ymir/hooks/ensure-wiki-binary.mjs
+echo "exit: $?"
+```
+
+Expected: exits 0, no output (fast path).
+
+- [ ] **Step 3: Smoke-test version mismatch path (intentional error)**
+
+```bash
+echo "0.1.0" > /tmp/ymir-test-plugin/wiki-cli/bin/.version
+CLAUDE_PLUGIN_ROOT=/tmp/ymir-test-plugin node plugins/ymir/hooks/ensure-wiki-binary.mjs
+echo "exit: $?"
+```
+
+Expected: exit non-zero, stderr shows `Failed to download` (no real release for 0.2.0 yet — correct loud failure).
+
+- [ ] **Step 4: Cleanup test artifacts**
+
+```bash
+rm -rf /tmp/ymir-test-plugin
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ymir/hooks/ensure-wiki-binary.mjs
+git commit -m "feat(ymir): add SessionStart hook to auto-download wiki binary"
+```
+
+---
+
+## Task 3: `hooks/hooks.json` — wire SessionStart hook
+
+**Files:**
+- Create: `plugins/ymir/hooks/hooks.json`
+
+- [ ] **Step 1: Create hook config**
+
+Create `plugins/ymir/hooks/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ensure-wiki-binary.mjs\"",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- [ ] **Step 2: Validate JSON**
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('plugins/ymir/hooks/hooks.json','utf8')); console.log('valid')"
+```
+
+Expected: `valid`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/ymir/hooks/hooks.json
+git commit -m "feat(ymir): register ensure-wiki-binary as SessionStart hook"
+```
+
+---
+
+## Task 4: `.github/workflows/release-please.yml` — add compile job
+
+**Files:**
+- Modify: `.github/workflows/release-please.yml`
+
+- [ ] **Step 1: Read current file**
+
+```bash
+cat .github/workflows/release-please.yml
+```
+
+Note: if PR#3 has already been merged + rebased, the file will have a `test` job and `needs: test` on the `release-please` job. In that case replace the entire `jobs:` block below accordingly — the `compile` job only needs `needs: release-please`.
+
+- [ ] **Step 2: Replace file contents**
+
+Overwrite `.github/workflows/release-please.yml` with:
+
+```yaml
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.rp.outputs.release_created }}
+      tag_name: ${{ steps.rp.outputs.tag_name }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: rp
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+
+  compile:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugins/ymir/wiki-cli
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - run: bun install --frozen-lockfile
+      - name: Compile all targets
+        run: |
+          bun build ./src/cli.ts --compile --target=bun-darwin-arm64  --outfile dist/wiki-darwin-arm64
+          bun build ./src/cli.ts --compile --target=bun-darwin-x64    --outfile dist/wiki-darwin-x64
+          bun build ./src/cli.ts --compile --target=bun-linux-x64     --outfile dist/wiki-linux-x64
+          bun build ./src/cli.ts --compile --target=bun-linux-aarch64 --outfile dist/wiki-linux-arm64
+      - name: Generate checksums
+        run: cd dist && sha256sum wiki-darwin-arm64 wiki-darwin-x64 wiki-linux-x64 wiki-linux-arm64 > SHA256SUMS.txt
+      - name: Upload to release
+        working-directory: plugins/ymir/wiki-cli
+        run: |
+          gh release upload "$TAG" \
+            dist/wiki-darwin-arm64 \
+            dist/wiki-darwin-x64 \
+            dist/wiki-linux-x64 \
+            dist/wiki-linux-arm64 \
+            dist/SHA256SUMS.txt
+        env:
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+> **If PR#3 is already merged:** the `release-please` job will already have `needs: test` and `outputs` from that PR. In that case only ADD the `compile` job block — do not overwrite the `release-please` job's existing changes.
+
+- [ ] **Step 3: Validate YAML**
+
+```bash
+node -e "
+const fs = require('fs');
+const txt = fs.readFileSync('.github/workflows/release-please.yml','utf8');
+// Basic checks: no tabs, has 'compile:', has 'release_created'
+if (txt.includes('\t')) throw new Error('TAB in YAML');
+if (!txt.includes('compile:')) throw new Error('missing compile job');
+if (!txt.includes('release_created')) throw new Error('missing output');
+console.log('checks pass');
+"
+```
+
+Expected: `checks pass`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/release-please.yml
+git commit -m "ci: add compile job to attach binaries to GitHub Releases"
+```
+
+---
+
+## Task 5: Update CLI invocation paths in SKILL.md and SCHEMA.md
+
+**Files:**
+- Modify: `plugins/ymir/SKILL.md` line 87
+- Modify: `plugins/ymir/templates/wiki/SCHEMA.md` line 19
+
+- [ ] **Step 1: Update SKILL.md line 87**
+
+Find:
+```
+   `node ${CLAUDE_PLUGIN_ROOT}/wiki-cli/dist/cli.js --root ./wiki validate`
+```
+
+Replace with:
+```
+   `${CLAUDE_PLUGIN_ROOT}/wiki-cli/bin/wiki --root ./wiki validate`
+```
+
+- [ ] **Step 2: Verify SKILL.md has no remaining dist/cli.js references**
+
+```bash
+grep -n "dist/cli.js" plugins/ymir/SKILL.md
+```
+
+Expected: no output (zero matches).
+
+- [ ] **Step 3: Update SCHEMA.md line 19**
+
+Find:
+```
+node ${CLAUDE_PLUGIN_ROOT}/wiki-cli/dist/cli.js --root ./wiki <command>
+```
+
+Replace with:
+```
+${CLAUDE_PLUGIN_ROOT}/wiki-cli/bin/wiki --root ./wiki <command>
+```
+
+- [ ] **Step 4: Verify SCHEMA.md has no remaining dist/cli.js references**
+
+```bash
+grep -n "dist/cli.js" plugins/ymir/templates/wiki/SCHEMA.md
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ymir/SKILL.md plugins/ymir/templates/wiki/SCHEMA.md
+git commit -m "feat(ymir): invoke wiki CLI via binary, not node dist/cli.js"
+```
+
+---
+
+## Task 6: Cleanup — gitignore dist, add compile scripts, remove tracked dist/cli.js
+
+**Files:**
+- Modify: `plugins/ymir/wiki-cli/.gitignore`
+- Modify: `plugins/ymir/wiki-cli/package.json`
+
+- [ ] **Step 1: Update .gitignore**
+
+Current content of `plugins/ymir/wiki-cli/.gitignore`:
+```
+node_modules/
+```
+
+New content:
+```
+node_modules/
+dist/
+```
+
+- [ ] **Step 2: Remove dist/cli.js from git tracking**
+
+```bash
+git rm --cached plugins/ymir/wiki-cli/dist/cli.js
+```
+
+Expected: `rm 'plugins/ymir/wiki-cli/dist/cli.js'`
+
+- [ ] **Step 3: Add compile scripts to package.json**
+
+Current `scripts` block in `plugins/ymir/wiki-cli/package.json`:
+```json
+"scripts": {
+  "build": "bun build ./src/cli.ts --outfile dist/cli.js --target node --format esm --banner \"#!/usr/bin/env node\" && chmod +x dist/cli.js",
+  "test": "bun test",
+  "typecheck": "tsc --noEmit"
+},
+```
+
+New `scripts` block:
+```json
+"scripts": {
+  "build": "bun build ./src/cli.ts --outfile dist/cli.js --target node --format esm --banner \"#!/usr/bin/env node\" && chmod +x dist/cli.js",
+  "test": "bun test",
+  "typecheck": "tsc --noEmit",
+  "compile:darwin-arm64": "bun build ./src/cli.ts --compile --target=bun-darwin-arm64  --outfile dist/wiki-darwin-arm64",
+  "compile:darwin-x64":   "bun build ./src/cli.ts --compile --target=bun-darwin-x64    --outfile dist/wiki-darwin-x64",
+  "compile:linux-x64":    "bun build ./src/cli.ts --compile --target=bun-linux-x64     --outfile dist/wiki-linux-x64",
+  "compile:linux-arm64":  "bun build ./src/cli.ts --compile --target=bun-linux-aarch64 --outfile dist/wiki-linux-arm64"
+},
+```
+
+- [ ] **Step 4: Verify tests still pass (bun test excludes dist, no regressions)**
+
+```bash
+cd plugins/ymir/wiki-cli && bun test
+```
+
+Expected: `45 pass  0 fail`
+
+- [ ] **Step 5: Verify typecheck passes**
+
+```bash
+cd plugins/ymir/wiki-cli && bun run typecheck
+```
+
+Expected: exits 0, no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/ymir/wiki-cli/.gitignore plugins/ymir/wiki-cli/package.json
+git commit -m "chore(wiki-cli): gitignore dist/, add compile scripts for local use"
+```
+
+---
+
+## Task 7: Final verification + push
+
+- [ ] **Step 1: Confirm all expected files exist**
+
+```bash
+ls plugins/ymir/hooks/hooks.json plugins/ymir/hooks/ensure-wiki-binary.mjs \
+   plugins/ymir/wiki-cli/src/platform.ts plugins/ymir/wiki-cli/test/platform.test.ts
+```
+
+Expected: all four paths printed, no "No such file" errors.
+
+- [ ] **Step 2: Confirm dist/cli.js no longer tracked**
+
+```bash
+git ls-files plugins/ymir/wiki-cli/dist/
+```
+
+Expected: no output (empty — dist no longer tracked).
+
+- [ ] **Step 3: Confirm no remaining dist/cli.js invocation references**
+
+```bash
+grep -rn "wiki-cli/dist/cli.js" plugins/
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Run full test suite one final time**
+
+```bash
+cd plugins/ymir/wiki-cli && bun test
+```
+
+Expected: `45 pass  0 fail`
+
+- [ ] **Step 5: Push branch**
+
+```bash
+git push -u origin feat/wiki-cli-publish
+```
+
+- [ ] **Step 6: Open PR against main**
+
+```bash
+gh pr create \
+  --base main \
+  --head feat/wiki-cli-publish \
+  --title "feat: publish wiki CLI binaries to GitHub Releases with auto-fetch hook" \
+  --body "$(cat <<'EOF'
+## Summary
+- CI `compile` job cross-compiles 4 platform binaries (darwin-arm64/x64, linux-x64/arm64) on every release and uploads them + SHA256SUMS.txt to the GitHub Release.
+- Plugin `SessionStart` hook (`hooks/ensure-wiki-binary.mjs`) auto-downloads the matching binary on first session use or version change. Fails loudly (exit 2) on any failure — no fallback.
+- SKILL and SCHEMA.md updated to invoke `wiki-cli/bin/wiki` instead of `node dist/cli.js`.
+- `dist/` gitignored and untracked.
+
+## Merge order
+Merge PR#3 (`feat/ci-test-step`) first. Then rebase this branch if needed.
+
+## Test plan
+- [ ] `bun test` — 45 pass / 0 fail (38 existing + 7 platform detection tests)
+- [ ] `bun run typecheck` — exit 0
+- [ ] Smoke-test hook fast path: existing stamp matches → exits 0
+- [ ] Smoke-test hook failure: mismatched stamp → loud stderr + non-zero exit
+- [ ] CI compile job runs green on first release
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+- Platform detection module → Task 1 ✓
+- Hook download/verify/fail-loud → Task 2 ✓
+- Plugin hook config → Task 3 ✓
+- CI compile job + release upload → Task 4 ✓
+- SKILL invocation path → Task 5 ✓
+- gitignore dist + untrack dist/cli.js → Task 6 ✓
+- Version source = plugin.json (not wiki-cli/package.json) → Task 2 step 1 ✓
+- Fail fast, no fallback → Task 2 (hook exits 2), Task 5 (no node fallback in SKILL) ✓
+
+**Merge note (flagged in Task 4):** If PR#3 is already merged before this branch, the release-please.yml will already have the `test` job. Do not overwrite it; only add the `compile` job.

--- a/wiki/raw/wiki-harness-design.md
+++ b/wiki/raw/wiki-harness-design.md
@@ -1,0 +1,214 @@
+# Ymir Wiki Harness + Wiki CLI — Design
+
+Date: 2026-06-17
+Status: Approved (design); implementation pending
+Branch: `feat/ymir-wiki-harness`
+
+## Background
+
+The "LLM Wiki" pattern: instead of query-time RAG over raw documents, an LLM
+incrementally builds and maintains a persistent, interlinked markdown knowledge
+base. Three layers:
+
+1. **Raw sources** — immutable source documents the LLM reads but never edits.
+2. **The wiki** — LLM-generated markdown (summaries, entity/concept pages,
+   index, log). The LLM owns this layer.
+3. **The schema** — a document telling the LLM how the wiki is structured and
+   what workflows to follow (ingest / query / lint).
+
+Ymir already lists "wiki / context" as harness concern #4 (see
+`plugins/ymir/SKILL.md`). This design implements that concern: Ymir becomes the
+**generator** that scaffolds an LLM-maintained wiki skeleton into a target
+project, plus the tooling and enforcement that keep the wiki deterministic.
+
+## Goals
+
+- Ymir scaffolds a generic, domain-agnostic wiki skeleton into the current
+  project (cwd).
+- The LLM **never hand-writes or hand-edits** wiki documents. All wiki writes go
+  through a CLI that owns structure (filename, frontmatter, placement,
+  cross-link validation, formatting) and updates index + log atomically.
+- The CLI **formats then validates** every write; invalid input is rejected so
+  the LLM must fix it → deterministic, schema-conformant docs.
+- A hard mechanism (PreToolUse hook) prevents the LLM from bypassing the CLI via
+  direct file edits.
+- Search/read uses `qmd` (local hybrid BM25 + vector + LLM-rerank markdown
+  search).
+
+## Non-Goals (YAGNI)
+
+- No domain tailoring (personal / research / book / business presets). One
+  generic skeleton only.
+- Ymir does not implement ingest/query/lint logic itself. That logic lives in
+  the scaffolded `SCHEMA.md` (workflows) + the CLI (mechanics).
+- No application/business code generation (existing Ymir boundary).
+
+## Decisions (resolved during brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Where the pattern lives | Ymir "wiki / context" harness piece (Ymir = generator) |
+| Tailoring | Generic skeleton, no domain presets |
+| Schema home | Dedicated `wiki/SCHEMA.md` + short pointer from project `CLAUDE.md` |
+| Search tooling | `qmd` integration (read side) |
+| Wiki write tooling | Dedicated CLI; LLM must use it, never hand-write |
+| CLI language | TypeScript / Node |
+| CLI distribution | Bundled in the Ymir plugin, invoked via `${CLAUDE_PLUGIN_ROOT}` |
+| Hand-write prevention | PreToolUse hook that blocks `Write`/`Edit`/`MultiEdit` on wiki content paths |
+| CLI help | `commander` auto-help + a `help` command for LLM clarity |
+
+## Architecture
+
+Two sides:
+
+- **Write + validate side** = the Wiki CLI (bundled in plugin).
+- **Read + search side** = `qmd` (configured against `wiki/`).
+
+Enforcement is two-layer: the PreToolUse hook blocks direct edits live; the CLI
+guarantees format + validation on the sanctioned write path.
+
+### Component 1 — Wiki CLI (`plugins/ymir/wiki-cli/`)
+
+TypeScript/Node, shipped in the plugin and committed as a bundled
+`dist/cli.js`. Invoked as:
+
+```
+node ${CLAUDE_PLUGIN_ROOT}/wiki-cli/dist/cli.js <cmd> --root <project>/wiki [...]
+```
+
+(`--root` defaults to `./wiki` relative to cwd.)
+
+Toolchain: built and tested with **bun** (`bun build` for the self-contained
+bundle, `bun test` for the suite). No `tsup`/`vitest`/`esbuild` dev chain.
+
+Dependencies:
+
+- `commander` — CLI parsing + auto-generated help.
+- `js-yaml` (4.2.0+, parsed with `JSON_SCHEMA`) — frontmatter read/write via a
+  small internal `frontmatter.ts` (replaces `gray-matter` to drop its
+  vulnerable bundled js-yaml and avoid YAML date coercion / merge-key DoS).
+- `remark` (+ `remark-frontmatter`, `remark-gfm`) — markdown parse + format.
+- `zod` — frontmatter schema validation per page type.
+
+Commands:
+
+| Command | Job |
+|---|---|
+| `ingest --raw <path> --title <t> [--body -]` | Read body from stdin/flag → wrap in source-page template, inject validated frontmatter, write `wiki/sources/<slug>.md`, rebuild `index.md`, append `log.md`. |
+| `note --type entity\|concept\|topic --name <n> [--body -]` | Create/update a note page in `wiki/notes/<slug>.md` with validated frontmatter; rebuild index; append log. |
+| `index` | Rebuild `index.md` from all pages (LLM never edits index by hand). |
+| `log <op> <title>` | Append a `## [YYYY-MM-DD] <op> \| <title>` entry to `log.md`. |
+| `validate` | Check frontmatter schema, broken `[[wikilinks]]`, orphan pages, stale markers, and format. Exit nonzero on failure. |
+| `fmt` | Normalize markdown via remark. |
+| `query <q>` | Wrap a `qmd` search over `wiki/` (read side). |
+| `help` | Print command list, examples, page types, and frontmatter contract for the LLM. |
+
+Behavior: every **write** command internally runs `fmt` then `validate` before
+committing the file. On validation failure: no write, nonzero exit, actionable
+error message so the LLM corrects its input.
+
+Page-type frontmatter contract (enforced by zod):
+
+- Common: `title`, `type`, `date`, `tags[]`.
+- Source page: + `source` (raw path), `ingested` date.
+- Note page (entity/concept/topic): + `source_count`.
+
+(`tags`/`date`/`source_count` enable Obsidian Dataview.)
+
+### Component 2 — Scaffolded wiki (into target project cwd)
+
+```
+<project>/
+├── wiki/
+│   ├── raw/        # immutable sources, user drops files here (.gitkeep)
+│   ├── sources/    # CLI-written source summaries
+│   ├── notes/      # CLI-written entity/concept/topic pages
+│   ├── index.md    # CLI-rebuilt catalog
+│   ├── log.md      # CLI-appended timeline
+│   └── SCHEMA.md   # rules: MUST use CLI; command reference; page conventions; qmd usage
+├── <qmd config>    # qmd indexes wiki/ (exact filename pinned from qmd README at build)
+├── .claude/
+│   ├── settings.json          # PreToolUse hook entry (merged, not clobbered)
+│   └── hooks/
+│       └── block-wiki-edits.mjs
+└── CLAUDE.md       # pointer block → wiki/SCHEMA.md ("wiki edits ONLY via wiki-cli")
+```
+
+`SCHEMA.md` is the enforcement contract in prose: ingest/query/lint workflows
+expressed as CLI invocations, page conventions, and qmd usage. It is the only
+wiki file the LLM may read as instructions (and may hand-edit — it is rules, not
+content).
+
+### Component 3 — PreToolUse hook (hand-write prevention)
+
+Scaffolded **into the target project** (not the plugin) so protection persists
+even if Ymir is uninstalled and so project-relative paths resolve reliably.
+
+- `.claude/settings.json`: a PreToolUse hook with matcher `Write|Edit|MultiEdit`
+  calling `.claude/hooks/block-wiki-edits.mjs`. Merge into existing settings if
+  present; never clobber.
+- `block-wiki-edits.mjs`: reads `tool_input.file_path`; if the path is under
+  `wiki/sources/`, `wiki/notes/`, `wiki/index.md`, or `wiki/log.md` → **deny**
+  with message: *"Wiki docs are CLI-managed. Use wiki-cli (ingest/note/index/log),
+  not direct edits."*
+- **Allow**: `wiki/raw/**` (user-owned sources) and `wiki/SCHEMA.md` (rules).
+
+Exact deny mechanism (exit code vs JSON `permissionDecision: "deny"`) pinned
+from the Claude Code hook docs at build.
+
+### Component 4 — qmd integration (read side)
+
+Scaffold writes a qmd config targeting `wiki/`, and a `SCHEMA.md` section with:
+install, index command, query examples, and the optional MCP-server route.
+Exact config filename/syntax pinned from the qmd README at build time.
+
+## Ymir code changes
+
+- **New** `plugins/ymir/wiki-cli/` — TS source, `package.json`, bundled
+  `dist/cli.js`.
+- **New** `plugins/ymir/templates/wiki/` — `SCHEMA.md`, `index.md` seed,
+  `log.md` seed, `.gitkeep`s, qmd config template.
+- **New** `plugins/ymir/templates/hooks/` — `block-wiki-edits.mjs` +
+  `settings.json` snippet.
+- **Edit** `plugins/ymir/SKILL.md` — implement the `wiki/context` branch of
+  Step 2: create dirs, copy templates, render project name, install hook +
+  settings (merge), append CLAUDE.md pointer, run `wiki validate` to confirm a
+  healthy scaffold. Keep boundary: Ymir scaffolds `SCHEMA.md`; thereafter
+  `SCHEMA.md` + CLI drive ingest/query/lint, not the Ymir dispatcher.
+- **Edit** `README.md` / `plugin.json` — note the wiki piece + CLI are
+  implemented.
+
+## Data flow
+
+- **Ingest:** user drops file in `wiki/raw/` → asks LLM to ingest → LLM reads
+  raw, discusses, calls `wiki ingest` with extracted body → CLI writes source
+  page (formatted + validated), rebuilds index, appends log → LLM updates
+  related notes via `wiki note`.
+- **Query:** LLM calls `wiki query` (qmd) → reads returned pages → synthesizes
+  answer with citations → optionally files the answer back via `wiki note`.
+- **Lint:** LLM runs `wiki validate` → fixes reported contradictions/orphans/
+  stale/broken-links by issuing further CLI commands.
+
+## Error handling
+
+- CLI write commands are atomic-ish: format + validate before write; on failure,
+  abort with nonzero exit and a clear message; no partial files.
+- `validate` is the single source of truth for "is the wiki healthy"; SKILL.md
+  runs it post-scaffold.
+- Hook denies direct edits with a message pointing at the CLI.
+
+## Testing
+
+- CLI unit/integration tests (`bun test`) for: each command happy path,
+  frontmatter validation rejection, broken-link detection, index rebuild, log
+  append format, `fmt` idempotence.
+- Scaffold smoke test: run the SKILL flow against a temp dir, assert the tree +
+  a passing `wiki validate`.
+- Hook test: simulate a `Write` to `wiki/notes/x.md` → expect deny; to
+  `wiki/raw/x.md` → expect allow.
+
+## Open items pinned to build time
+
+- qmd config filename/syntax (from qmd README).
+- Claude Code PreToolUse deny mechanism exact shape (from hook docs).
+- CLI bundling approach (`bun build --target node --format esm` → single self-contained `dist/cli.js`).

--- a/wiki/raw/wiki-harness-plan.md
+++ b/wiki/raw/wiki-harness-plan.md
@@ -1,0 +1,1699 @@
+# Ymir Wiki Harness + Wiki CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Ymir scaffold an LLM-maintained wiki skeleton into a target project, backed by a TypeScript CLI that owns all wiki writes (format + validate) and a PreToolUse hook that blocks hand-editing.
+
+**Architecture:** A bundled TS/Node CLI (`plugins/ymir/wiki-cli`) is the only sanctioned write path — it injects frontmatter, places files, formats, validates, and rebuilds index/log atomically. A PreToolUse hook scaffolded into the target project denies `Write/Edit/MultiEdit` on wiki content paths. `qmd` provides read/search. Ymir's `SKILL.md` wiki branch copies templates + installs the hook.
+
+**Tech Stack:** TypeScript (ESM, Node 18+), commander, gray-matter, remark (+ remark-frontmatter, remark-gfm, remark-stringify), zod, tsup (bundle), vitest (test). qmd (external, read side).
+
+---
+
+## File Structure
+
+```
+plugins/ymir/wiki-cli/
+├── package.json
+├── tsconfig.json
+├── tsup.config.ts
+├── vitest.config.ts
+├── src/
+│   ├── cli.ts            # commander entry → dist/cli.js
+│   ├── paths.ts          # root resolution, slug, page paths
+│   ├── schema.ts         # zod frontmatter schemas + TS types
+│   ├── format.ts         # remark-based markdown formatter
+│   ├── pages.ts          # render source/note page (frontmatter + body)
+│   ├── store.ts          # fs read/write/list over the wiki dir
+│   ├── index-build.ts    # rebuild index.md
+│   ├── wikilog.ts        # append log.md entry
+│   ├── validate.ts       # frontmatter + link + orphan checks
+│   └── commands/
+│       ├── ingest.ts
+│       ├── note.ts
+│       ├── reindex.ts    # the `index` command (renamed to avoid index.ts clash)
+│       ├── logcmd.ts     # the `log` command
+│       ├── validatecmd.ts
+│       ├── fmtcmd.ts
+│       ├── query.ts
+│       └── help.ts
+└── test/
+    ├── paths.test.ts
+    ├── schema.test.ts
+    ├── format.test.ts
+    ├── pages.test.ts
+    ├── index-build.test.ts
+    ├── wikilog.test.ts
+    ├── validate.test.ts
+    ├── ingest.test.ts
+    ├── note.test.ts
+    └── query.test.ts
+
+plugins/ymir/templates/
+├── wiki/
+│   ├── SCHEMA.md
+│   ├── index.seed.md
+│   ├── log.seed.md
+│   └── gitkeep            # copied as .gitkeep into raw/ sources/ notes/
+└── hooks/
+    ├── block-wiki-edits.mjs
+    └── settings.snippet.json
+
+plugins/ymir/SKILL.md      # modify: implement wiki/context branch
+README.md                  # modify
+plugins/ymir/.claude-plugin/plugin.json  # modify (version bump)
+```
+
+**Module boundaries:** `store` is the only fs layer. `schema`/`format`/`pages`/`index-build`/`wikilog`/`validate` are pure-ish logic on strings/objects. `commands/*` wire logic + store + run fmt→validate before any write. `cli.ts` only does commander plumbing.
+
+---
+
+## Task 0: CLI project scaffold
+
+**Files:**
+- Create: `plugins/ymir/wiki-cli/package.json`
+- Create: `plugins/ymir/wiki-cli/tsconfig.json`
+- Create: `plugins/ymir/wiki-cli/tsup.config.ts`
+- Create: `plugins/ymir/wiki-cli/vitest.config.ts`
+
+- [ ] **Step 1: Create package.json**
+
+```json
+{
+  "name": "@ymir/wiki-cli",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": { "wiki": "dist/cli.js" },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "commander": "^12.1.0",
+    "gray-matter": "^4.0.3",
+    "remark": "^15.0.1",
+    "remark-frontmatter": "^5.0.0",
+    "remark-gfm": "^4.0.0",
+    "remark-stringify": "^11.0.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.5.0",
+    "tsup": "^8.2.4",
+    "typescript": "^5.5.4",
+    "vitest": "^2.0.5"
+  }
+}
+```
+
+- [ ] **Step 2: Create tsconfig.json**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "outDir": "dist"
+  },
+  "include": ["src", "test"]
+}
+```
+
+- [ ] **Step 3: Create tsup.config.ts**
+
+```ts
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: { cli: "src/cli.ts" },
+  format: ["esm"],
+  target: "node18",
+  bundle: true,
+  clean: true,
+  banner: { js: "#!/usr/bin/env node" },
+});
+```
+
+- [ ] **Step 4: Create vitest.config.ts**
+
+```ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: { environment: "node", include: ["test/**/*.test.ts"] },
+});
+```
+
+- [ ] **Step 5: Install deps**
+
+Run: `cd plugins/ymir/wiki-cli && npm install`
+Expected: `node_modules` created, no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/ymir/wiki-cli/package.json plugins/ymir/wiki-cli/package-lock.json plugins/ymir/wiki-cli/tsconfig.json plugins/ymir/wiki-cli/tsup.config.ts plugins/ymir/wiki-cli/vitest.config.ts
+git commit -m "chore(wiki-cli): scaffold TS project (tsup + vitest)"
+```
+
+---
+
+## Task 1: paths + slug
+
+**Files:**
+- Create: `plugins/ymir/wiki-cli/src/paths.ts`
+- Test: `plugins/ymir/wiki-cli/test/paths.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { slugify, sourcePath, notePath, wikiPaths } from "../src/paths.js";
+
+describe("slugify", () => {
+  it("lowercases, trims, hyphenates", () => {
+    expect(slugify("  Hello World!  ")).toBe("hello-world");
+    expect(slugify("API & Auth/v2")).toBe("api-auth-v2");
+  });
+});
+
+describe("paths", () => {
+  it("builds source/note paths under root", () => {
+    expect(sourcePath("/w", "My Title")).toBe("/w/sources/my-title.md");
+    expect(notePath("/w", "Token Bucket")).toBe("/w/notes/token-bucket.md");
+  });
+  it("exposes core wiki paths", () => {
+    const p = wikiPaths("/w");
+    expect(p.index).toBe("/w/index.md");
+    expect(p.log).toBe("/w/log.md");
+    expect(p.sourcesDir).toBe("/w/sources");
+    expect(p.notesDir).toBe("/w/notes");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- paths`
+Expected: FAIL — cannot find module `../src/paths.js`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import { join } from "node:path";
+
+export function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function wikiPaths(root: string) {
+  return {
+    root,
+    index: join(root, "index.md"),
+    log: join(root, "log.md"),
+    schema: join(root, "SCHEMA.md"),
+    rawDir: join(root, "raw"),
+    sourcesDir: join(root, "sources"),
+    notesDir: join(root, "notes"),
+  };
+}
+
+export function sourcePath(root: string, title: string): string {
+  return join(root, "sources", `${slugify(title)}.md`);
+}
+
+export function notePath(root: string, name: string): string {
+  return join(root, "notes", `${slugify(name)}.md`);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- paths`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ymir/wiki-cli/src/paths.ts plugins/ymir/wiki-cli/test/paths.test.ts
+git commit -m "feat(wiki-cli): path + slug helpers"
+```
+
+---
+
+## Task 2: frontmatter schema (zod)
+
+**Files:**
+- Create: `plugins/ymir/wiki-cli/src/schema.ts`
+- Test: `plugins/ymir/wiki-cli/test/schema.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { sourceFrontmatter, noteFrontmatter, NoteType } from "../src/schema.js";
+
+describe("sourceFrontmatter", () => {
+  it("accepts valid source frontmatter", () => {
+    const r = sourceFrontmatter.safeParse({
+      title: "T", type: "source", date: "2026-06-17",
+      tags: ["a"], source: "raw/t.pdf", ingested: "2026-06-17",
+    });
+    expect(r.success).toBe(true);
+  });
+  it("rejects missing source path", () => {
+    const r = sourceFrontmatter.safeParse({
+      title: "T", type: "source", date: "2026-06-17", tags: [],
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("noteFrontmatter", () => {
+  it("accepts valid note frontmatter", () => {
+    const r = noteFrontmatter.safeParse({
+      title: "Token Bucket", type: "concept", date: "2026-06-17",
+      tags: [], source_count: 2,
+    });
+    expect(r.success).toBe(true);
+  });
+  it("rejects bad note type", () => {
+    const r = noteFrontmatter.safeParse({
+      title: "X", type: "source", date: "2026-06-17", tags: [], source_count: 0,
+    });
+    expect(r.success).toBe(false);
+  });
+  it("enumerates note types", () => {
+    expect(NoteType.options).toEqual(["entity", "concept", "topic"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- schema`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import { z } from "zod";
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "date must be YYYY-MM-DD");
+
+export const NoteType = z.enum(["entity", "concept", "topic"]);
+export type NoteTypeT = z.infer<typeof NoteType>;
+
+export const sourceFrontmatter = z.object({
+  title: z.string().min(1),
+  type: z.literal("source"),
+  date: isoDate,
+  tags: z.array(z.string()),
+  source: z.string().min(1),
+  ingested: isoDate,
+});
+export type SourceFrontmatter = z.infer<typeof sourceFrontmatter>;
+
+export const noteFrontmatter = z.object({
+  title: z.string().min(1),
+  type: NoteType,
+  date: isoDate,
+  tags: z.array(z.string()),
+  source_count: z.number().int().nonnegative(),
+});
+export type NoteFrontmatter = z.infer<typeof noteFrontmatter>;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- schema`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ymir/wiki-cli/src/schema.ts plugins/ymir/wiki-cli/test/schema.test.ts
+git commit -m "feat(wiki-cli): zod frontmatter schemas"
+```
+
+---
+
+## Task 3: markdown formatter
+
+**Files:**
+- Create: `plugins/ymir/wiki-cli/src/format.ts`
+- Test: `plugins/ymir/wiki-cli/test/format.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { formatMarkdown } from "../src/format.js";
+
+describe("formatMarkdown", () => {
+  it("normalizes and is idempotent", async () => {
+    const messy = "# Title\n\n\n\nsome   text\n";
+    const once = await formatMarkdown(messy);
+    const twice = await formatMarkdown(once);
+    expect(once).toBe(twice);
+    expect(once).toContain("# Title");
+  });
+  it("preserves frontmatter block", async () => {
+    const src = "---\ntitle: T\n---\n# H\n";
+    const out = await formatMarkdown(src);
+    expect(out.startsWith("---")).toBe(true);
+    expect(out).toContain("title: T");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- format`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import { remark } from "remark";
+import remarkFrontmatter from "remark-frontmatter";
+import remarkGfm from "remark-gfm";
+
+const processor = remark()
+  .use(remarkFrontmatter, ["yaml"])
+  .use(remarkGfm);
+
+export async function formatMarkdown(input: string): Promise<string> {
+  const file = await processor.process(input);
+  return String(file);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- format`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ymir/wiki-cli/src/format.ts plugins/ymir/wiki-cli/test/format.test.ts
+git commit -m "feat(wiki-cli): remark markdown formatter"
+```
+
+---
+
+## Task 4: page rendering
+
+**Files:**
+- Create: `plugins/ymir/wiki-cli/src/pages.ts`
+- Test: `plugins/ymir/wiki-cli/test/pages.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { renderSourcePage, renderNotePage } from "../src/pages.js";
+
+describe("renderSourcePage", () => {
+  it("emits validated frontmatter + body", async () => {
+    const out = await renderSourcePage({
+      title: "My Doc", source: "raw/my-doc.pdf", date: "2026-06-17",
+      tags: ["x"], body: "Key point.",
+    });
+    expect(out).toContain("type: source");
+    expect(out).toContain("source: raw/my-doc.pdf");
+    expect(out).toContain("# My Doc");
+    expect(out).toContain("Key point.");
+  });
+});
+
+describe("renderNotePage", () => {
+  it("emits note frontmatter + body", async () => {
+    const out = await renderNotePage({
+      name: "Token Bucket", type: "concept", date: "2026-06-17",
+      tags: [], sourceCount: 1, body: "A rate limiter.",
+    });
+    expect(out).toContain("type: concept");
+    expect(out).toContain("source_count: 1");
+    expect(out).toContain("# Token Bucket");
+  });
+  it("throws on invalid frontmatter", async () => {
+    await expect(renderNotePage({
+      name: "", type: "concept", date: "bad", tags: [], sourceCount: 0, body: "x",
+    })).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- pages`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import matter from "gray-matter";
+import { formatMarkdown } from "./format.js";
+import { sourceFrontmatter, noteFrontmatter, type NoteTypeT } from "./schema.js";
+
+export interface SourcePageInput {
+  title: string; source: string; date: string; tags: string[]; body: string;
+}
+export interface NotePageInput {
+  name: string; type: NoteTypeT; date: string; tags: string[];
+  sourceCount: number; body: string;
+}
+
+export async function renderSourcePage(i: SourcePageInput): Promise<string> {
+  const fm = sourceFrontmatter.parse({
+    title: i.title, type: "source", date: i.date,
+    tags: i.tags, source: i.source, ingested: i.date,
+  });
+  const md = matter.stringify(`# ${i.title}\n\n${i.body}\n`, fm);
+  return formatMarkdown(md);
+}
+
+export async function renderNotePage(i: NotePageInput): Promise<string> {
+  const fm = noteFrontmatter.parse({
+    title: i.name, type: i.type, date: i.date,
+    tags: i.tags, source_count: i.sourceCount,
+  });
+  const md = matter.stringify(`# ${i.name}\n\n${i.body}\n`, fm);
+  return formatMarkdown(md);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- pages`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ymir/wiki-cli/src/pages.ts plugins/ymir/wiki-cli/test/pages.test.ts
+git commit -m "feat(wiki-cli): source/note page rendering"
+```
+
+---
+
+## Task 5: store (fs layer)
+
+**Files:**
+- Create: `plugins/ymir/wiki-cli/src/store.ts`
+- Test: `plugins/ymir/wiki-cli/test/store.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writePage, readPage, listPages, appendFileLine } from "../src/store.js";
+
+let root: string;
+beforeEach(() => { root = mkdtempSync(join(tmpdir(), "wiki-")); });
+
+describe("store", () => {
+  it("writes and reads a page (creating dirs)", () => {
+    const p = join(root, "notes", "a.md");
+    writePage(p, "hello");
+    expect(readPage(p)).toBe("hello");
+  });
+  it("lists .md files in a dir, empty if missing", () => {
+    expect(listPages(join(root, "notes"))).toEqual([]);
+    writePage(join(root, "notes", "a.md"), "x");
+    writePage(join(root, "notes", "b.md"), "y");
+    expect(listPages(join(root, "notes")).sort()).toEqual(["a.md", "b.md"]);
+  });
+  it("appends a line to a file", () => {
+    const f = join(root, "log.md");
+    appendFileLine(f, "line1");
+    appendFileLine(f, "line2");
+    expect(readPage(f)).toBe("line1\nline2\n");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- store`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import {
+  mkdirSync, writeFileSync, readFileSync, readdirSync,
+  existsSync, appendFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+
+export function writePage(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, "utf8");
+}
+
+export function readPage(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+export function listPages(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter((f) => f.endsWith(".md"));
+}
+
+export function appendFileLine(path: string, line: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  appendFileSync(path, `${line}\n`, "utf8");
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- store`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ymir/wiki-cli/src/store.ts plugins/ymir/wiki-cli/test/store.test.ts
+git commit -m "feat(wiki-cli): fs store layer"
+```
+
+---
+
+## Task 6: index rebuild
+
+**Files:**
+- Create: `plugins/ymir/wiki-cli/src/index-build.ts`
+- Test: `plugins/ymir/wiki-cli/test/index-build.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writePage } from "../src/store.js";
+import { buildIndex } from "../src/index-build.js";
+
+let root: string;
+beforeEach(() => { root = mkdtempSync(join(tmpdir(), "wiki-")); });
+
+describe("buildIndex", () => {
+  it("catalogs sources and notes by category with links", () => {
+    writePage(join(root, "sources", "doc-a.md"),
+      "---\ntitle: Doc A\ntype: source\ndate: 2026-06-17\ntags: []\nsource: raw/a.pdf\ningested: 2026-06-17\n---\n# Doc A\n");
+    writePage(join(root, "notes", "token-bucket.md"),
+      "---\ntitle: Token Bucket\ntype: concept\ndate: 2026-06-17\ntags: []\nsource_count: 1\n---\n# Token Bucket\n");
+    const md = buildIndex(root);
+    expect(md).toContain("# Wiki Index");
+    expect(md).toContain("## Sources");
+    expect(md).toContain("[Doc A](sources/doc-a.md)");
+    expect(md).toContain("## Notes");
+    expect(md).toContain("[Token Bucket](notes/token-bucket.md)");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- index-build`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import matter from "gray-matter";
+import { join } from "node:path";
+import { listPages, readPage } from "./store.js";
+
+function entries(root: string, sub: string): string[] {
+  return listPages(join(root, sub))
+    .sort()
+    .map((file) => {
+      const fm = matter(readPage(join(root, sub, file))).data as { title?: string };
+      const title = fm.title ?? file.replace(/\.md$/, "");
+      return `- [${title}](${sub}/${file})`;
+    });
+}
+
+export function buildIndex(root: string): string {
+  const sources = entries(root, "sources");
+  const notes = entries(root, "notes");
+  const lines = ["# Wiki Index", ""];
+  lines.push("## Sources", "");
+  lines.push(...(sources.length ? sources : ["_none yet_"]), "");
+  lines.push("## Notes", "");
+  lines.push(...(notes.length ? notes : ["_none yet_"]), "");
+  return lines.join("\n") + "\n";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- index-build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ymir/wiki-cli/src/index-build.ts plugins/ymir/wiki-cli/test/index-build.test.ts
+git commit -m "feat(wiki-cli): index.md rebuild"
+```
+
+---
+
+## Task 7: log append
+
+**Files:**
+- Create: `plugins/ymir/wiki-cli/src/wikilog.ts`
+- Test: `plugins/ymir/wiki-cli/test/wikilog.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readPage } from "../src/store.js";
+import { appendLog } from "../src/wikilog.js";
+
+let root: string;
+beforeEach(() => { root = mkdtempSync(join(tmpdir(), "wiki-")); });
+
+describe("appendLog", () => {
+  it("appends a greppable dated entry", () => {
+    appendLog(root, "ingest", "Doc A", "2026-06-17");
+    const md = readPage(join(root, "log.md"));
+    expect(md).toContain("## [2026-06-17] ingest | Doc A");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- wikilog`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import { appendFileLine } from "./store.js";
+import { wikiPaths } from "./paths.js";
+
+export type LogOp = "ingest" | "note" | "index" | "query" | "lint";
+
+export function appendLog(root: string, op: LogOp, title: string, date: string): void {
+  appendFileLine(wikiPaths(root).log, `## [${date}] ${op} | ${title}`);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- wikilog`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ymir/wiki-cli/src/wikilog.ts plugins/ymir/wiki-cli/test/wikilog.test.ts
+git commit -m "feat(wiki-cli): log.md append"
+```
+
+---
+
+## Task 8: validate
+
+**Files:**
+- Create: `plugins/ymir/wiki-cli/src/validate.ts`
+- Test: `plugins/ymir/wiki-cli/test/validate.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writePage } from "../src/store.js";
+import { validateWiki } from "../src/validate.js";
+
+let root: string;
+beforeEach(() => { root = mkdtempSync(join(tmpdir(), "wiki-")); });
+
+const goodNote = (title: string, body = "") =>
+  `---\ntitle: ${title}\ntype: concept\ndate: 2026-06-17\ntags: []\nsource_count: 0\n---\n# ${title}\n\n${body}\n`;
+
+describe("validateWiki", () => {
+  it("passes a clean wiki", () => {
+    writePage(join(root, "notes", "a.md"), goodNote("A", "see [[B]]"));
+    writePage(join(root, "notes", "b.md"), goodNote("B", "see [[A]]"));
+    const r = validateWiki(root);
+    expect(r.ok).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+  it("flags bad frontmatter", () => {
+    writePage(join(root, "notes", "bad.md"), "---\ntitle: X\ntype: nope\n---\n# X\n");
+    const r = validateWiki(root);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("frontmatter"))).toBe(true);
+  });
+  it("flags broken wikilinks", () => {
+    writePage(join(root, "notes", "a.md"), goodNote("A", "see [[Ghost]]"));
+    const r = validateWiki(root);
+    expect(r.errors.some((e) => e.includes("broken link") && e.includes("Ghost"))).toBe(true);
+  });
+  it("warns on orphan notes", () => {
+    writePage(join(root, "notes", "a.md"), goodNote("A"));
+    const r = validateWiki(root);
+    expect(r.warnings.some((w) => w.includes("orphan") && w.includes("A"))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- validate`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import matter from "gray-matter";
+import { join } from "node:path";
+import { listPages, readPage } from "./store.js";
+import { sourceFrontmatter, noteFrontmatter } from "./schema.js";
+import { slugify } from "./paths.js";
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+interface Page { rel: string; title: string; body: string; links: string[]; }
+
+function loadDir(root: string, sub: string, errors: string[]): Page[] {
+  const out: Page[] = [];
+  for (const file of listPages(join(root, sub))) {
+    const rel = `${sub}/${file}`;
+    const parsed = matter(readPage(join(root, sub, file)));
+    const schema = sub === "sources" ? sourceFrontmatter : noteFrontmatter;
+    const res = schema.safeParse(parsed.data);
+    if (!res.success) {
+      errors.push(`${rel}: invalid frontmatter — ${res.error.issues.map((i) => i.message).join("; ")}`);
+    }
+    const title = (parsed.data as { title?: string }).title ?? file.replace(/\.md$/, "");
+    const links = [...parsed.content.matchAll(/\[\[([^\]]+)\]\]/g)].map((m) => m[1]!.trim());
+    out.push({ rel, title, body: parsed.content, links });
+  }
+  return out;
+}
+
+export function validateWiki(root: string): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const sources = loadDir(root, "sources", errors);
+  const notes = loadDir(root, "notes", errors);
+  const all = [...sources, ...notes];
+
+  const slugs = new Set(all.map((p) => slugify(p.title)));
+  const inbound = new Set<string>();
+  for (const p of all) {
+    for (const link of p.links) {
+      const target = slugify(link);
+      if (!slugs.has(target)) {
+        errors.push(`${p.rel}: broken link [[${link}]]`);
+      } else {
+        inbound.add(target);
+      }
+    }
+  }
+  for (const n of notes) {
+    if (!inbound.has(slugify(n.title))) {
+      warnings.push(`orphan note: ${n.rel} (${n.title})`);
+    }
+  }
+  return { ok: errors.length === 0, errors, warnings };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- validate`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ymir/wiki-cli/src/validate.ts plugins/ymir/wiki-cli/test/validate.test.ts
+git commit -m "feat(wiki-cli): wiki validation (frontmatter, links, orphans)"
+```
+
+---
+
+## Task 9: ingest command
+
+**Files:**
+- Create: `plugins/ymir/wiki-cli/src/commands/ingest.ts`
+- Test: `plugins/ymir/wiki-cli/test/ingest.test.ts`
+
+Note: `today()` is a parameter so tests are deterministic.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readPage } from "../src/store.js";
+import { runIngest } from "../src/commands/ingest.js";
+
+let root: string;
+beforeEach(() => { root = mkdtempSync(join(tmpdir(), "wiki-")); });
+
+describe("runIngest", () => {
+  it("writes a validated source page, rebuilds index, appends log", async () => {
+    await runIngest({
+      root, raw: "raw/a.pdf", title: "Doc A",
+      body: "Key takeaway. See [[Doc A]].", today: "2026-06-17",
+    });
+    const page = readPage(join(root, "sources", "doc-a.md"));
+    expect(page).toContain("type: source");
+    expect(page).toContain("source: raw/a.pdf");
+    expect(readPage(join(root, "index.md"))).toContain("[Doc A](sources/doc-a.md)");
+    expect(readPage(join(root, "log.md"))).toContain("## [2026-06-17] ingest | Doc A");
+    expect(existsSync(join(root, "sources", "doc-a.md"))).toBe(true);
+  });
+
+  it("rejects when result fails validation (no file written)", async () => {
+    await expect(runIngest({
+      root, raw: "raw/a.pdf", title: "Doc A",
+      body: "See [[Ghost]].", today: "2026-06-17",
+    })).rejects.toThrow(/broken link/);
+    expect(existsSync(join(root, "sources", "doc-a.md"))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- ingest`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Write-then-validate-then-rollback: write the page, run `validateWiki`; if it fails, delete the page and throw.
+
+```ts
+import { rmSync } from "node:fs";
+import { renderSourcePage } from "../pages.js";
+import { writePage, readPage } from "../store.js";
+import { sourcePath, wikiPaths } from "../paths.js";
+import { buildIndex } from "../index-build.js";
+import { appendLog } from "../wikilog.js";
+import { validateWiki } from "../validate.js";
+
+export interface IngestInput {
+  root: string; raw: string; title: string; body: string; today: string;
+}
+
+export async function runIngest(i: IngestInput): Promise<string> {
+  const page = await renderSourcePage({
+    title: i.title, source: i.raw, date: i.today, tags: [], body: i.body,
+  });
+  const path = sourcePath(i.root, i.title);
+  writePage(path, page);
+
+  const result = validateWiki(i.root);
+  if (!result.ok) {
+    rmSync(path);
+    throw new Error(`ingest rejected:\n${result.errors.join("\n")}`);
+  }
+
+  writePage(wikiPaths(i.root).index, buildIndex(i.root));
+  appendLog(i.root, "ingest", i.title, i.today);
+  return path;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- ingest`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ymir/wiki-cli/src/commands/ingest.ts plugins/ymir/wiki-cli/test/ingest.test.ts
+git commit -m "feat(wiki-cli): ingest command (write→validate→index→log)"
+```
+
+---
+
+## Task 10: note command
+
+**Files:**
+- Create: `plugins/ymir/wiki-cli/src/commands/note.ts`
+- Test: `plugins/ymir/wiki-cli/test/note.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writePage, readPage } from "../src/store.js";
+import { runNote } from "../src/commands/note.js";
+
+let root: string;
+beforeEach(() => { root = mkdtempSync(join(tmpdir(), "wiki-")); });
+
+const seedNote = (title: string, body = "") =>
+  `---\ntitle: ${title}\ntype: concept\ndate: 2026-06-17\ntags: []\nsource_count: 0\n---\n# ${title}\n\n${body}\n`;
+
+describe("runNote", () => {
+  it("creates a validated note, rebuilds index, appends log", async () => {
+    // existing inbound link so the new note is not an orphan-blocking error (orphan is warning only)
+    await runNote({
+      root, type: "concept", name: "Token Bucket",
+      body: "A rate limiter.", today: "2026-06-17",
+    });
+    const page = readPage(join(root, "notes", "token-bucket.md"));
+    expect(page).toContain("type: concept");
+    expect(readPage(join(root, "index.md"))).toContain("[Token Bucket](notes/token-bucket.md)");
+    expect(readPage(join(root, "log.md"))).toContain("## [2026-06-17] note | Token Bucket");
+  });
+
+  it("rejects on broken link and writes nothing", async () => {
+    await expect(runNote({
+      root, type: "concept", name: "X", body: "see [[Ghost]]", today: "2026-06-17",
+    })).rejects.toThrow(/broken link/);
+    expect(existsSync(join(root, "notes", "x.md"))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- note`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import { existsSync, rmSync } from "node:fs";
+import matter from "gray-matter";
+import { renderNotePage } from "../pages.js";
+import { writePage, readPage } from "../store.js";
+import { notePath, wikiPaths } from "../paths.js";
+import { buildIndex } from "../index-build.js";
+import { appendLog } from "../wikilog.js";
+import { validateWiki } from "../validate.js";
+import type { NoteTypeT } from "../schema.js";
+
+export interface NoteInput {
+  root: string; type: NoteTypeT; name: string; body: string; today: string;
+}
+
+export async function runNote(i: NoteInput): Promise<string> {
+  const path = notePath(i.root, i.name);
+  const existed = existsSync(path);
+  const prevSourceCount = existed
+    ? ((matter(readPage(path)).data as { source_count?: number }).source_count ?? 0)
+    : 0;
+
+  const page = await renderNotePage({
+    name: i.name, type: i.type, date: i.today,
+    tags: [], sourceCount: prevSourceCount, body: i.body,
+  });
+  const prev = existed ? readPage(path) : null;
+  writePage(path, page);
+
+  const result = validateWiki(i.root);
+  if (!result.ok) {
+    if (prev === null) rmSync(path);
+    else writePage(path, prev);
+    throw new Error(`note rejected:\n${result.errors.join("\n")}`);
+  }
+
+  writePage(wikiPaths(i.root).index, buildIndex(i.root));
+  appendLog(i.root, "note", i.name, i.today);
+  return path;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- note`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ymir/wiki-cli/src/commands/note.ts plugins/ymir/wiki-cli/test/note.test.ts
+git commit -m "feat(wiki-cli): note command (create/update with rollback)"
+```
+
+---
+
+## Task 11: query command (qmd wrapper)
+
+**Files:**
+- Create: `plugins/ymir/wiki-cli/src/commands/query.ts`
+- Test: `plugins/ymir/wiki-cli/test/query.test.ts`
+
+qmd is invoked as a subprocess. The runner is injected so tests don't shell out.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { runQuery } from "../src/commands/query.js";
+
+describe("runQuery", () => {
+  it("invokes qmd query with json/files flags and returns stdout", async () => {
+    const calls: { cmd: string; args: string[] }[] = [];
+    const fakeRun = async (cmd: string, args: string[]) => {
+      calls.push({ cmd, args });
+      return '[{"path":"wiki/notes/a.md","score":0.9}]';
+    };
+    const out = await runQuery({ root: "/w", q: "rate limit", runner: fakeRun });
+    expect(calls[0]!.cmd).toBe("qmd");
+    expect(calls[0]!.args).toContain("query");
+    expect(calls[0]!.args).toContain("rate limit");
+    expect(calls[0]!.args).toContain("--json");
+    expect(out).toContain("wiki/notes/a.md");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- query`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import { spawn } from "node:child_process";
+
+export type Runner = (cmd: string, args: string[]) => Promise<string>;
+
+const defaultRunner: Runner = (cmd, args) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let out = "";
+    let err = "";
+    child.stdout.on("data", (d) => (out += d));
+    child.stderr.on("data", (d) => (err += d));
+    child.on("error", reject);
+    child.on("close", (code) =>
+      code === 0 ? resolve(out) : reject(new Error(err || `qmd exited ${code}`)),
+    );
+  });
+
+export interface QueryInput {
+  root: string; q: string; runner?: Runner;
+}
+
+export async function runQuery(i: QueryInput): Promise<string> {
+  const run = i.runner ?? defaultRunner;
+  return run("qmd", ["query", i.q, "--json", "--files"]);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- query`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ymir/wiki-cli/src/commands/query.ts plugins/ymir/wiki-cli/test/query.test.ts
+git commit -m "feat(wiki-cli): query command (qmd wrapper)"
+```
+
+---
+
+## Task 12: CLI entrypoint (commander) + help
+
+**Files:**
+- Create: `plugins/ymir/wiki-cli/src/cli.ts`
+- Create: `plugins/ymir/wiki-cli/src/commands/help.ts`
+
+No unit test (thin wiring); covered by the build smoke test in Step 4 + scaffold smoke test in Task 15.
+
+- [ ] **Step 1: Write the help text module**
+
+```ts
+export const HELP_TEXT = `wiki — Ymir wiki CLI (the ONLY way to write wiki docs)
+
+You must NOT hand-write or hand-edit files under wiki/sources, wiki/notes,
+index.md, or log.md. Use these commands; they format + validate every write.
+
+Commands:
+  ingest --raw <path> --title <t>     Ingest a source from wiki/raw into a summary page.
+                                      Body is read from STDIN.
+  note --type <entity|concept|topic> --name <n>
+                                      Create/update a synthesis note. Body from STDIN.
+  index                               Rebuild index.md from all pages.
+  log <op> <title>                    Append a dated entry to log.md.
+  validate                            Check frontmatter, [[links]], orphans. Exit !=0 on error.
+  fmt                                 Format all wiki markdown (remark).
+  query <q>                           Search the wiki via qmd (read side).
+  help                                Show this text.
+
+Page conventions:
+  Source page frontmatter: title, type=source, date, tags[], source, ingested
+  Note page frontmatter:   title, type=entity|concept|topic, date, tags[], source_count
+  Cross-reference other pages with [[Exact Title]].
+
+Examples:
+  echo "Key points..." | wiki ingest --raw raw/paper.pdf --title "Rate Limiting"
+  echo "A token-bucket limiter. See [[Rate Limiting]]." | wiki note --type concept --name "Token Bucket"
+  wiki query "how does backoff work"
+  wiki validate
+`;
+
+export function runHelp(): void {
+  process.stdout.write(HELP_TEXT);
+}
+```
+
+- [ ] **Step 2: Write cli.ts**
+
+`--root` defaults to `./wiki`. Body-bearing commands read STDIN. `validate` exits nonzero on errors.
+
+```ts
+import { Command } from "commander";
+import { readFileSync } from "node:fs";
+import { runIngest } from "./commands/ingest.js";
+import { runNote } from "./commands/note.js";
+import { runQuery } from "./commands/query.js";
+import { runHelp } from "./commands/help.js";
+import { buildIndex } from "./index-build.js";
+import { appendLog, type LogOp } from "./wikilog.js";
+import { validateWiki } from "./validate.js";
+import { formatMarkdown } from "./format.js";
+import { writePage, readPage, listPages } from "./store.js";
+import { wikiPaths } from "./paths.js";
+import { NoteType } from "./schema.js";
+import { join } from "node:path";
+
+const today = () => new Date().toISOString().slice(0, 10);
+const readStdin = () => readFileSync(0, "utf8");
+
+const program = new Command();
+program.name("wiki").description("Ymir wiki CLI").option("--root <dir>", "wiki root", "wiki");
+
+program
+  .command("ingest")
+  .requiredOption("--raw <path>")
+  .requiredOption("--title <title>")
+  .action(async (opts) => {
+    const root = program.opts().root as string;
+    const path = await runIngest({ root, raw: opts.raw, title: opts.title, body: readStdin(), today: today() });
+    process.stdout.write(`wrote ${path}\n`);
+  });
+
+program
+  .command("note")
+  .requiredOption("--type <type>")
+  .requiredOption("--name <name>")
+  .action(async (opts) => {
+    const root = program.opts().root as string;
+    const type = NoteType.parse(opts.type);
+    const path = await runNote({ root, type, name: opts.name, body: readStdin(), today: today() });
+    process.stdout.write(`wrote ${path}\n`);
+  });
+
+program.command("index").action(async () => {
+  const root = program.opts().root as string;
+  writePage(wikiPaths(root).index, buildIndex(root));
+  process.stdout.write("rebuilt index.md\n");
+});
+
+program.command("log").argument("<op>").argument("<title>").action((op: string, title: string) => {
+  const root = program.opts().root as string;
+  appendLog(root, op as LogOp, title, today());
+});
+
+program.command("validate").action(() => {
+  const root = program.opts().root as string;
+  const r = validateWiki(root);
+  for (const w of r.warnings) process.stdout.write(`warning: ${w}\n`);
+  for (const e of r.errors) process.stderr.write(`error: ${e}\n`);
+  if (!r.ok) process.exit(1);
+  process.stdout.write("wiki valid\n");
+});
+
+program.command("fmt").action(async () => {
+  const root = program.opts().root as string;
+  for (const sub of ["sources", "notes"] as const) {
+    for (const f of listPages(join(root, sub))) {
+      const p = join(root, sub, f);
+      writePage(p, await formatMarkdown(readPage(p)));
+    }
+  }
+  process.stdout.write("formatted\n");
+});
+
+program.command("query").argument("<q>").action(async (q: string) => {
+  const root = program.opts().root as string;
+  process.stdout.write(await runQuery({ root, q }));
+});
+
+program.command("help").action(() => runHelp());
+
+program.parseAsync();
+```
+
+- [ ] **Step 3: Build the bundle**
+
+Run: `cd plugins/ymir/wiki-cli && npm run build`
+Expected: `dist/cli.js` created, no type errors.
+
+- [ ] **Step 4: Smoke-test the built CLI**
+
+```bash
+cd plugins/ymir/wiki-cli
+TMP=$(mktemp -d)
+echo "Key points. See [[Rate Limiting]]." | node dist/cli.js --root "$TMP" ingest --raw raw/p.pdf --title "Rate Limiting"
+node dist/cli.js --root "$TMP" validate
+node dist/cli.js help | head -1
+```
+
+Expected: `wrote .../sources/rate-limiting.md`, then `wiki valid`, then the help banner line.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ymir/wiki-cli/src/cli.ts plugins/ymir/wiki-cli/src/commands/help.ts plugins/ymir/wiki-cli/dist
+git commit -m "feat(wiki-cli): commander entrypoint + help, build bundle"
+```
+
+---
+
+## Task 13: wiki templates
+
+**Files:**
+- Create: `plugins/ymir/templates/wiki/SCHEMA.md`
+- Create: `plugins/ymir/templates/wiki/index.seed.md`
+- Create: `plugins/ymir/templates/wiki/log.seed.md`
+- Create: `plugins/ymir/templates/wiki/gitkeep`
+
+- [ ] **Step 1: Create SCHEMA.md**
+
+```markdown
+# Wiki Schema & Rules
+
+This wiki is an LLM-maintained knowledge base. **You (the LLM) never hand-write
+or hand-edit wiki documents.** All writes go through the Ymir wiki CLI, which
+formats and validates every change. Direct edits to `sources/`, `notes/`,
+`index.md`, and `log.md` are blocked by a PreToolUse hook.
+
+## Layers
+- `raw/` — immutable sources. You may read these; never edit them. The user adds files here.
+- `sources/` — one CLI-written summary page per ingested source.
+- `notes/` — CLI-written entity / concept / topic pages (the synthesis).
+- `index.md` — CLI-rebuilt catalog. Never edit by hand.
+- `log.md` — CLI-appended timeline. Never edit by hand.
+
+## The CLI
+Invoke via the bundled binary:
+
+```
+node ${CLAUDE_PLUGIN_ROOT}/wiki-cli/dist/cli.js --root ./wiki <command>
+```
+
+Run `... help` for the full command reference. Key commands:
+- `ingest --raw <raw/path> --title <t>` (body on STDIN) — summarize a source.
+- `note --type entity|concept|topic --name <n>` (body on STDIN) — synthesis page.
+- `index` — rebuild the catalog.
+- `validate` — health check (frontmatter, `[[links]]`, orphans).
+- `query <q>` — search via qmd.
+
+## Page conventions
+- Cross-reference pages with `[[Exact Title]]`. The CLI validates every link target exists.
+- Frontmatter is injected by the CLI — do not write it yourself.
+
+## Operations
+- **Ingest:** user drops a file in `raw/` → you read it, discuss takeaways → call
+  `ingest` with the extracted body → then update related `notes` via `note`.
+- **Query:** call `query` → read returned pages → answer with citations →
+  optionally file the answer back as a `note`.
+- **Lint:** run `validate` → fix reported issues by issuing further CLI commands.
+
+## Search (qmd) setup
+One-time, on this machine:
+
+```
+qmd collection add ./wiki --name PROJECT_NAME-wiki
+qmd embed
+```
+
+Then `wiki query "..."` (which shells out to `qmd query --json --files`).
+Optional tighter integration: add a `qmd` MCP server (`qmd mcp`) to your client.
+```
+
+- [ ] **Step 2: Create index.seed.md**
+
+```markdown
+# Wiki Index
+
+## Sources
+
+_none yet_
+
+## Notes
+
+_none yet_
+```
+
+- [ ] **Step 3: Create log.seed.md**
+
+```markdown
+# Wiki Log
+
+```
+
+- [ ] **Step 4: Create gitkeep (empty file)**
+
+Create `plugins/ymir/templates/wiki/gitkeep` as an empty file (copied to `raw/.gitkeep`, `sources/.gitkeep`, `notes/.gitkeep` during scaffold).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ymir/templates/wiki
+git commit -m "feat(ymir): wiki scaffold templates (SCHEMA, seeds, gitkeep)"
+```
+
+---
+
+## Task 14: PreToolUse hook template
+
+**Files:**
+- Create: `plugins/ymir/templates/hooks/block-wiki-edits.mjs`
+- Create: `plugins/ymir/templates/hooks/settings.snippet.json`
+- Test: `plugins/ymir/wiki-cli/test/hook.test.ts`
+
+The hook script has no project deps (pure Node), so it can be unit-tested by spawning it with stdin JSON.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+const HOOK = join(__dirname, "..", "..", "templates", "hooks", "block-wiki-edits.mjs");
+
+function runHook(input: object) {
+  const r = spawnSync("node", [HOOK], { input: JSON.stringify(input), encoding: "utf8" });
+  return { stdout: r.stdout, status: r.status };
+}
+
+describe("block-wiki-edits hook", () => {
+  it("denies Write to wiki/notes", () => {
+    const { stdout } = runHook({ tool_name: "Write", cwd: "/p", tool_input: { file_path: "/p/wiki/notes/a.md" } });
+    expect(stdout).toContain('"permissionDecision": "deny"');
+  });
+  it("denies Edit to wiki/index.md", () => {
+    const { stdout } = runHook({ tool_name: "Edit", cwd: "/p", tool_input: { file_path: "/p/wiki/index.md" } });
+    expect(stdout).toContain('"permissionDecision": "deny"');
+  });
+  it("allows Write to wiki/raw", () => {
+    const { stdout } = runHook({ tool_name: "Write", cwd: "/p", tool_input: { file_path: "/p/wiki/raw/a.pdf" } });
+    expect(stdout.trim()).toBe("");
+  });
+  it("allows Write to wiki/SCHEMA.md", () => {
+    const { stdout } = runHook({ tool_name: "Write", cwd: "/p", tool_input: { file_path: "/p/wiki/SCHEMA.md" } });
+    expect(stdout.trim()).toBe("");
+  });
+  it("allows unrelated files", () => {
+    const { stdout } = runHook({ tool_name: "Write", cwd: "/p", tool_input: { file_path: "/p/src/app.ts" } });
+    expect(stdout.trim()).toBe("");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd plugins/ymir/wiki-cli && npm test -- hook`
+Expected: FAIL — hook file does not exist (spawn error / empty stdout).
+
+- [ ] **Step 3: Write the hook script**
+
+`plugins/ymir/templates/hooks/block-wiki-edits.mjs`:
+
+```js
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
+const input = JSON.parse(readFileSync(0, "utf8"));
+const file = input?.tool_input?.file_path ?? "";
+
+// normalize to a project-relative-ish path for matching
+const norm = file.replaceAll("\\", "/");
+
+const blocked =
+  /\/wiki\/sources\//.test(norm) ||
+  /\/wiki\/notes\//.test(norm) ||
+  /\/wiki\/index\.md$/.test(norm) ||
+  /\/wiki\/log\.md$/.test(norm);
+
+if (blocked) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason:
+          "Wiki docs are CLI-managed. Use the Ymir wiki CLI (ingest/note/index/log) instead of editing wiki files directly. Allowed direct edits: wiki/raw/** and wiki/SCHEMA.md.",
+      },
+    }),
+  );
+}
+process.exit(0);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd plugins/ymir/wiki-cli && npm test -- hook`
+Expected: PASS (all 5).
+
+- [ ] **Step 5: Create settings.snippet.json**
+
+`plugins/ymir/templates/hooks/settings.snippet.json` (merged into the project's `.claude/settings.json` during scaffold):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/.claude/hooks/block-wiki-edits.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/ymir/templates/hooks plugins/ymir/wiki-cli/test/hook.test.ts
+git commit -m "feat(ymir): PreToolUse hook blocking direct wiki edits"
+```
+
+---
+
+## Task 15: SKILL.md wiki/context branch
+
+**Files:**
+- Modify: `plugins/ymir/SKILL.md`
+
+Replace the Step 2 TODO stub with a concrete, executable description of the
+wiki/context action. (Ymir is skill-driven, so this is prose the agent follows,
+not code — but it must be exact and reference the real templates + CLI.)
+
+- [ ] **Step 1: Read current SKILL.md Step 2**
+
+Run: `sed -n '49,68p' plugins/ymir/SKILL.md`
+Expected: shows the `## Step 2 — Scaffold` TODO block and `## Boundaries`.
+
+- [ ] **Step 2: Replace the Step 2 TODO with the wiki branch**
+
+Replace the block from `## Step 2 — Scaffold` up to (but not including) `## Boundaries` with:
+
+````markdown
+## Step 2 — Scaffold
+
+Map the intent to a harness concern and scaffold it into the current project
+(cwd). Other concerns (lint, CI, rules, CLAUDE.md) are still stubbed; the
+**wiki / context** concern is implemented below.
+
+### wiki / context
+
+Triggered by intents like `ymir add context`, `ymir add wiki`, or as part of
+`ymir init`. This lays down an LLM-maintained wiki backed by the Ymir wiki CLI.
+
+Do all of the following with tools (Bash/Write), in order:
+
+1. **Create the tree** under the project root:
+   - `wiki/raw/`, `wiki/sources/`, `wiki/notes/` — each with a `.gitkeep`
+     (copy `${CLAUDE_PLUGIN_ROOT}/templates/wiki/gitkeep`).
+   - `wiki/SCHEMA.md` — copy `${CLAUDE_PLUGIN_ROOT}/templates/wiki/SCHEMA.md`,
+     then replace the literal `PROJECT_NAME` with the current directory's base
+     name.
+   - `wiki/index.md` — copy `templates/wiki/index.seed.md`.
+   - `wiki/log.md` — copy `templates/wiki/log.seed.md`.
+2. **Install the hook**:
+   - Copy `${CLAUDE_PLUGIN_ROOT}/templates/hooks/block-wiki-edits.mjs` to
+     `.claude/hooks/block-wiki-edits.mjs`.
+   - Merge `templates/hooks/settings.snippet.json` into `.claude/settings.json`.
+     If `.claude/settings.json` exists, deep-merge the `hooks.PreToolUse` array
+     (append the matcher entry; do not clobber existing hooks). If it does not
+     exist, create it from the snippet.
+3. **Point CLAUDE.md at the wiki**: append (creating the file if absent) a block:
+
+   ```markdown
+   ## Wiki / Context
+   This project has an LLM-maintained wiki under `wiki/`. You MUST NOT hand-edit
+   wiki docs (`wiki/sources`, `wiki/notes`, `index.md`, `log.md`) — they are
+   managed by the Ymir wiki CLI and a PreToolUse hook blocks direct edits. See
+   `wiki/SCHEMA.md` for the rules and command reference.
+   ```
+4. **Verify**: run
+   `node ${CLAUDE_PLUGIN_ROOT}/wiki-cli/dist/cli.js --root ./wiki validate`
+   and confirm it prints `wiki valid`. If it errors, stop and report.
+5. **Tell the user** the qmd one-time setup (from `wiki/SCHEMA.md`):
+   `qmd collection add ./wiki --name <project>-wiki && qmd embed`.
+
+Never write application code; only the harness skeleton above.
+````
+
+- [ ] **Step 3: Verify the edit reads correctly**
+
+Run: `sed -n '36,120p' plugins/ymir/SKILL.md`
+Expected: the socratic-interview Step 1 remains, Step 2 now contains the wiki branch, `## Boundaries` still follows.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/ymir/SKILL.md
+git commit -m "feat(ymir): implement wiki/context scaffold branch in SKILL.md"
+```
+
+---
+
+## Task 16: scaffold smoke test + docs
+
+**Files:**
+- Create: `plugins/ymir/wiki-cli/test/scaffold.test.ts`
+- Modify: `README.md`
+- Modify: `plugins/ymir/.claude-plugin/plugin.json`
+
+- [ ] **Step 1: Write a scaffold smoke test**
+
+This emulates the SKILL.md file operations (copy templates, render name) and
+asserts a healthy wiki via the CLI library functions.
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync, cpSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, basename } from "node:path";
+import { validateWiki } from "../src/validate.js";
+
+const TPL = join(__dirname, "..", "..", "templates", "wiki");
+
+let proj: string;
+beforeEach(() => { proj = mkdtempSync(join(tmpdir(), "proj-")); });
+
+describe("wiki scaffold", () => {
+  it("produces a valid wiki from templates", () => {
+    const wiki = join(proj, "wiki");
+    for (const d of ["raw", "sources", "notes"]) {
+      cpSync(join(TPL, "gitkeep"), join(wiki, d, ".gitkeep"));
+    }
+    const schema = readFileSync(join(TPL, "SCHEMA.md"), "utf8")
+      .replaceAll("PROJECT_NAME", basename(proj));
+    writeFileSync(join(wiki, "SCHEMA.md"), schema);
+    cpSync(join(TPL, "index.seed.md"), join(wiki, "index.md"));
+    cpSync(join(TPL, "log.seed.md"), join(wiki, "log.md"));
+
+    expect(existsSync(join(wiki, "raw", ".gitkeep"))).toBe(true);
+    expect(schema).not.toContain("PROJECT_NAME");
+    const r = validateWiki(wiki);
+    expect(r.ok).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `cd plugins/ymir/wiki-cli && npm test`
+Expected: all suites PASS (paths, schema, format, pages, store, index-build, wikilog, validate, ingest, note, query, hook, scaffold).
+
+- [ ] **Step 3: Update README.md**
+
+Update the `## Status` section to reflect the wiki piece is implemented. Replace
+the existing Status block:
+
+```markdown
+## Status
+
+`v0.2.0`. The **wiki / context** harness piece is implemented: `/ymir add
+context` scaffolds an LLM-maintained `wiki/` (backed by the bundled wiki CLI in
+`plugins/ymir/wiki-cli`), installs a PreToolUse hook that blocks hand-editing
+wiki docs, and wires in `qmd` for search. The socratic interview and the other
+harness pieces (lint, CI, rules) are still stubbed.
+```
+
+- [ ] **Step 4: Bump plugin version**
+
+In `plugins/ymir/.claude-plugin/plugin.json`, change `"version": "0.1.0"` to
+`"version": "0.2.0"`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ymir/wiki-cli/test/scaffold.test.ts README.md plugins/ymir/.claude-plugin/plugin.json
+git commit -m "test(ymir): scaffold smoke test; docs + version bump to 0.2.0"
+```
+
+---
+
+## Final verification
+
+- [ ] Run `cd plugins/ymir/wiki-cli && npm run build && npm test` → bundle builds, all tests pass.
+- [ ] Manually run the SKILL.md wiki branch against a throwaway dir; confirm `validate` prints `wiki valid` and a `Write` to `wiki/notes/x.md` is denied by the hook.
+- [ ] Open a PR from `feat/ymir-wiki-harness` (do not merge to main directly).

--- a/wiki/sources/wiki-cli-publish-design-spec.md
+++ b/wiki/sources/wiki-cli-publish-design-spec.md
@@ -1,0 +1,16 @@
+---
+title: Wiki CLI Publish Design Spec
+type: source
+date: 2026-06-17
+tags: []
+source: raw/wiki-cli-publish-design.md
+ingested: 2026-06-17
+---
+
+# Wiki CLI Publish Design Spec
+
+Design (approved) for publishing the wiki CLI as standalone GitHub Release binaries and auto-fetching them on plugin use, so installers get a ready-to-run binary with no manual step and no Node runtime dependency.
+
+Goals: compile standalone single-file binaries on each release and publish them as GitHub Release assets; on plugin use, automatically fetch the matching-platform binary into a cached location; the LLM drives the wiki exclusively through this binary. Hard requirement: fail fast, no fallback — there is no `node dist/cli.js` path. If the SessionStart hook cannot download/verify the binary it writes a loud stderr error and exits non-zero; if the SKILL needs the binary and it is absent it stops with an explicit error; `dist/cli.js` is gitignored and never shipped at runtime. Non-goals: no Windows, no npm publishing, no self-update beyond a version-stamp check, no signing beyond sha256.
+
+Four bun --compile targets map to assets wiki-darwin-arm64 / -x64 / wiki-linux-x64 / -arm64 (selected by `uname -sm`), plus SHA256SUMS.txt. Components: (1) a CI `compile` job gated on release-please `release_created`, building all four targets and `gh release upload`ing them; (2) `src/platform.ts` pure `detectAssetLabel` (unit-tested, no network); (3) the SessionStart hook `ensure-wiki-binary.mjs` that reads the expected version from `plugin.json $.version` (release-please keeps it synced — not wiki-cli/package.json which drifts), no-ops if `bin/wiki` + `bin/.version` match, else detects platform, curls the asset + SHA256SUMS, sha256-verifies, installs to `bin/wiki` chmod 0755 and stamps `.version`; (4) SKILL/SCHEMA wiring to call `bin/wiki` not `dist/cli.js`. Flagged pre-existing issue: `.release-please-manifest.json`/`version.txt` at 0.1.0 while plugin.json/package.json at 0.2.0.

--- a/wiki/sources/wiki-cli-publish-implementation-plan.md
+++ b/wiki/sources/wiki-cli-publish-implementation-plan.md
@@ -1,0 +1,16 @@
+---
+title: Wiki CLI Publish Implementation Plan
+type: source
+date: 2026-06-17
+tags: []
+source: raw/wiki-cli-publish-plan.md
+ingested: 2026-06-17
+---
+
+# Wiki CLI Publish Implementation Plan
+
+Task-by-task implementation plan for compiling, publishing, and auto-fetching the wiki CLI binaries (TDD, checkbox steps, executed via superpowers subagent-driven-development).
+
+Goal: compile standalone wiki CLI binaries on every release, publish them as GitHub Release assets, and auto-download the matching-platform binary into the plugin on first session use — no fallback, fail loud. Architecture: a CI `compile` job (triggered by release-please) cross-compiles four platform binaries with `bun --compile` and attaches them + SHA256SUMS.txt to the GitHub Release; a plugin-level SessionStart hook (`hooks/ensure-wiki-binary.mjs`) checks for the binary every session start, downloads and sha256-verifies it on first use or version change, and exits non-zero on any failure; the SKILL calls the binary directly and `dist/` is gitignored.
+
+File map: create `src/platform.ts` (`detectAssetLabel(unameSM)` pure fn) + `test/platform.test.ts`; create `hooks/ensure-wiki-binary.mjs` + `hooks/hooks.json` (wires the hook to SessionStart); modify `.github/workflows/release-please.yml` (add outputs + compile job), `wiki-cli/package.json` (compile:\* scripts), `wiki-cli/.gitignore` (add dist/), and `SKILL.md` + `templates/wiki/SCHEMA.md` (swap `node .../dist/cli.js` for `.../bin/wiki`). Tech: Bun 1.3.14, GitHub Actions (release-please-action\@v4, setup-bun\@v2), curl + sha256sum. Merge order note: land the CI `test`-job PR first so compile chains test → release-please → compile.

--- a/wiki/sources/wiki-harness-design-spec.md
+++ b/wiki/sources/wiki-harness-design-spec.md
@@ -1,0 +1,16 @@
+---
+title: Wiki Harness Design Spec
+type: source
+date: 2026-06-17
+tags: []
+source: raw/wiki-harness-design.md
+ingested: 2026-06-17
+---
+
+# Wiki Harness Design Spec
+
+Design (approved) for Ymir's wiki/context harness. Implements the "LLM Wiki" pattern: instead of query-time RAG over raw documents, an LLM incrementally builds and maintains a persistent, interlinked markdown knowledge base. Three layers: raw sources (immutable, read-only to the LLM), the wiki (LLM-generated summaries/notes/index/log — the LLM owns this), and the schema (a document telling the LLM how the wiki is structured and which workflows to follow).
+
+Goals: Ymir scaffolds a generic, domain-agnostic wiki skeleton into cwd; the LLM never hand-writes wiki docs — all writes go through a CLI that owns structure (filename, frontmatter, placement, cross-link validation, formatting) and updates index+log atomically; the CLI formats then validates every write, rejecting invalid input so the LLM must fix it; a PreToolUse hook hard-blocks bypassing the CLI via direct edits; search uses qmd (hybrid BM25 + vector + LLM-rerank). Non-goals: no domain presets, no business code, Ymir itself does not implement ingest/query/lint logic (that lives in SCHEMA.md + the CLI).
+
+Architecture is two-sided: write+validate = the bundled TS/Node Wiki CLI; read+search = qmd. Four components: (1) the Wiki CLI (commander, js-yaml frontmatter, remark format, zod schema; commands ingest/note/index/log/validate/fmt/query/help; every write runs fmt then validate before committing); (2) the scaffolded wiki tree (raw/ sources/ notes/ index.md log.md SCHEMA.md); (3) the PreToolUse hook scaffolded into the target project (`block-wiki-edits.mjs` + merged settings.json) denying Write/Edit/MultiEdit on sources/, notes/, index.md, log.md while allowing raw/\*\* and SCHEMA.md; (4) qmd read-side config. Frontmatter contract (zod): common title/type/date/tags; source pages add source+ingested; note pages add source\_count.

--- a/wiki/sources/wiki-harness-implementation-plan.md
+++ b/wiki/sources/wiki-harness-implementation-plan.md
@@ -1,0 +1,16 @@
+---
+title: Wiki Harness Implementation Plan
+type: source
+date: 2026-06-17
+tags: []
+source: raw/wiki-harness-plan.md
+ingested: 2026-06-17
+---
+
+# Wiki Harness Implementation Plan
+
+Task-by-task implementation plan for the Ymir wiki harness, meant to be executed via superpowers subagent-driven-development / executing-plans (checkbox steps, TDD).
+
+Goal: make Ymir scaffold an LLM-maintained wiki skeleton into a target project, backed by a TypeScript CLI that owns all wiki writes (format + validate) and a PreToolUse hook that blocks hand-editing. Architecture: the bundled TS/Node CLI (`plugins/ymir/wiki-cli`) is the only sanctioned write path — it injects frontmatter, places files, formats, validates, and rebuilds index/log atomically; a PreToolUse hook scaffolded into the target project denies Write/Edit/MultiEdit on wiki content paths; qmd handles read/search; the SKILL wiki branch copies templates and installs the hook.
+
+CLI module layout: cli.ts (commander entry), paths.ts (root resolution, slug, page paths), schema.ts (zod frontmatter + types), format.ts (remark formatter), pages.ts (render source/note pages), store.ts (fs read/write/list), index-build.ts (rebuild index.md), wikilog.ts (append log.md), validate.ts (frontmatter + link + orphan checks), and commands/ for ingest/note/index/log/validate/fmt/query/help. Templates live under plugins/ymir/templates/ (wiki SCHEMA.md + index/log seeds + gitkeep; hook script + settings snippet). Each unit has a matching bun test. The plan was the source for the actually-shipped CLI.

--- a/wiki/sources/wiki-schema.md
+++ b/wiki/sources/wiki-schema.md
@@ -1,0 +1,16 @@
+---
+title: Wiki Schema
+type: source
+date: 2026-06-17
+tags: []
+source: raw/SCHEMA.md
+ingested: 2026-06-17
+---
+
+# Wiki Schema
+
+`wiki/SCHEMA.md` is the self-describing rules document for the LLM-maintained wiki — the only wiki file the LLM may read as instructions and hand-edit (it is rules, not content). Core rule: the LLM never hand-writes or hand-edits wiki documents; all writes go through the Ymir wiki CLI, which formats and validates every change. Direct edits to sources/, notes/, index.md, and log.md are blocked by a PreToolUse hook.
+
+Layers: raw/ — immutable sources (read, never edit; the user adds files here); sources/ — one CLI-written summary page per ingested source; notes/ — CLI-written entity/concept/topic synthesis pages; index.md — CLI-rebuilt catalog; log.md — CLI-appended timeline. The CLI is invoked via the bundled binary `wiki-cli/bin/wiki --root ./wiki <command>`. Key commands: `ingest --raw <raw/path> --title <t>` (body on STDIN) summarizes a source; `note --type entity|concept|topic --name <n>` (body on STDIN) writes a synthesis page; `index` rebuilds the catalog; `validate` health-checks frontmatter, wiki cross-links, and orphans; `query <q>` searches via qmd.
+
+Page conventions: cross-reference pages with double-bracketed exact titles (the CLI validates every link target exists); frontmatter is injected by the CLI — never hand-written. Operations: ingest (user drops a file in raw/ then the LLM reads, discusses, and calls ingest with the extracted body, then updates related notes); query (call query, read returned pages, answer with citations, optionally file the answer back as a note); lint (run validate, then fix reported issues via further CLI commands). Search is lightweight and keyword-only: a one-time `qmd collection add ./wiki --name <project>-wiki` builds the BM25 index — no `qmd embed`, no embeddings, and no local LLM. `wiki query` shells out to `qmd search --json --files`.

--- a/wiki/sources/ymir-readme.md
+++ b/wiki/sources/ymir-readme.md
@@ -1,0 +1,16 @@
+---
+title: Ymir README
+type: source
+date: 2026-06-17
+tags: []
+source: raw/README.md
+ingested: 2026-06-17
+---
+
+# Ymir README
+
+Ymir is a Claude Code plugin marketplace + plugin that scaffolds the mandatory project harness every repo should start with: rules, lint, CI lint, wiki/context, and CLAUDE.md/AGENT.md. It does not generate application code — it interviews the user about their techstack (Go vs TypeScript, frontend vs backend) and builds only the skeleton; the user then drives real development through Claude Code, steered by that harness.
+
+Ymir is one dispatcher skill, not a fixed command list: whatever follows `ymir` is the intent (`ymir init`, `ymir add lint`, `ymir add rules`, `ymir set up CI`). Layout: a `.claude-plugin/marketplace.json` marketplace plus `plugins/ymir/` (plugin.json + SKILL.md). Try locally via `/plugin marketplace add ./`, `/plugin install ymir@ymir`, `/reload-plugins`, then `/ymir init for this project`.
+
+Status at v0.2.0: the wiki/context harness piece is implemented — `/ymir add context` scaffolds an LLM-maintained `wiki/` backed by the bundled wiki CLI, installs a PreToolUse hook blocking hand-edits of wiki docs, and wires `qmd` for search. The socratic interview and other pieces (lint, CI, rules) are still stubbed.

--- a/wiki/sources/ymir-skill-dispatcher.md
+++ b/wiki/sources/ymir-skill-dispatcher.md
@@ -1,0 +1,16 @@
+---
+title: Ymir SKILL Dispatcher
+type: source
+date: 2026-06-17
+tags: []
+source: raw/SKILL.md
+ingested: 2026-06-17
+---
+
+# Ymir SKILL Dispatcher
+
+`plugins/ymir/SKILL.md` is the single dispatcher skill behind `/ymir`. It builds the harness skeleton for the current project (cwd) only — never application/business code. Harness concerns: (1) rules, (2) lint, (3) CI lint, (4) wiki/context, (5) CLAUDE.md/AGENT.md.
+
+The words after `ymir` are the intent (`$ARGUMENTS`); the skill maps them to a harness concern. `ymir init` runs the full flow (interview + scaffold every fitting piece); narrow actions (`add lint`, `add rules`, `set up CI`) do just that piece; empty arguments mean `init`; ambiguous input gets a short clarifying question.
+
+Step 1 is a socratic interview (AskUserQuestion) — because the user does not hand-write code, the stack cannot be inferred from files: ask Language (Go/TypeScript…), Layer (frontend/backend/both), one decision at a time, only what the action needs. Step 2 scaffolds. The wiki/context concern is the only implemented one: it is scaffolded by a single CLI call `wiki --root ./wiki init` — the CLI owns the tree, the hook, the `.claude/settings.json` entry, the CLAUDE.md block, and validation. It is idempotent; success ends with `wiki valid`. The skill must never copy templates or edit settings/CLAUDE.md directly. After scaffold, tell the user the one-time qmd setup. Boundaries: operate on cwd only, build only the skeleton, prefer asking over assuming.


### PR DESCRIPTION
## Summary
- Dogfoods the wiki harness on Ymir itself: `wiki init` scaffolds `wiki/` at the repo root, then `ingest` summarizes Ymir's own docs (README, SKILL, both design specs + implementation plans, and SCHEMA) as `sources/`, with four synthesis `notes/` (harness model, CLI command surface, publish/auto-fetch flow, init scaffold contract). Index rebuilt, `wiki validate` passes — every write via the CLI, no hand-edited wiki docs. Closes #9.
- Makes `wiki query` lightweight: shells out to `qmd search` (BM25 keyword) instead of `qmd query` (local-LLM rerank over vector embeddings). No `qmd embed`, no embedding model download, no local LLM — setup is a single `qmd collection add`. SCHEMA template + SKILL docs updated.
- Gitignores the runtime-fetched `wiki-cli/bin/` (SessionStart hook installs the per-platform binary there; the 62MB compiled binary is never committed).

## Test plan
- [x] `bun test` (65 pass) and `bun run typecheck` clean in `plugins/ymir/wiki-cli`.
- [x] `wiki init` → `wiki valid`; tree + hook + settings + CLAUDE.md block created.
- [x] 7 sources + 4 notes ingested via CLI; `wiki index` lists all; `wiki validate` prints `wiki valid` with no orphans.
- [x] `wiki query` returns relevant pages for `ensure-wiki-binary`, `PreToolUse hook`, `init scaffold` in ~0.12s each (BM25, no model load).
- [ ] Reviewer: confirm committing root `.claude/` (block-wiki-edits hook) + `CLAUDE.md` pointer into the Ymir repo is desired for dogfooding.