### PR TITLE
fix(ymir): fetch wiki binary from ymir-v<version> release tag

### DIFF
--- a/plugins/ymir/hooks/ensure-wiki-binary.mjs
+++ b/plugins/ymir/hooks/ensure-wiki-binary.mjs
@@ -58,7 +58,7 @@ try {
   process.exit(2);
 }
 
-const base     = `https://github.com/muitneliss/ymir/releases/download/v${pluginVersion}`;
+const base     = `https://github.com/muitneliss/ymir/releases/download/ymir-v${pluginVersion}`;
 const assetUrl = `${base}/wiki-${label}`;
 const sumsUrl  = `${base}/SHA256SUMS.txt`;
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
     ".": {
       "release-type": "simple",
       "package-name": "ymir",
-      "include-component-in-tag": false,
       "extra-files": [
         {
           "type": "json",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "simple",
       "package-name": "ymir",
+      "include-component-in-tag": false,
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Summary
- `ensure-wiki-binary.mjs` now builds the asset URL with the `ymir-v<version>` tag (was `v<version>`), matching the component-scoped tags release-please actually cuts. Component prefix is kept intentionally so the plugin can host multiple CLIs.
- Reverts the earlier config approach (no `include-component-in-tag` change).

## Verification
- Before: `curl .../download/v0.2.0/wiki-darwin-arm64` → 404.
- After: `curl .../download/ymir-v0.2.0/wiki-darwin-arm64` → 200.

## Still pending (separate, your call)
- The released `ymir-v0.2.0` binary is stale — still runs `qmd query` (local-LLM rerank). The lightweight `qmd search` ships only when binaries rebuild on the next release.