### PR TITLE
chore(ymir): bump to 0.2.1 for lightweight-query binary release

### DIFF
--- a/plugins/ymir/.claude-plugin/plugin.json
+++ b/plugins/ymir/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ymir",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Scaffolds a project harness — rules, lint, CI lint, wiki/context, and CLAUDE.md — by interviewing the user about their techstack. Builds only the skeleton; never generates application code.",
   "author": {
     "name": "articalam",


### PR DESCRIPTION
Bumps plugin.json to 0.2.1. Paired with a manual GitHub release `ymir-v0.2.1` whose binaries are rebuilt from current source (BM25 `qmd search`, no local LLM). The hook fetches `ymir-v0.2.1` assets per this version. Tests: 65 pass.