### PR TITLE
docs: install ymir from GitHub marketplace instead of local path

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ ymir add rules
 ymir set up CI
 ```
 
-## Try it locally
+## Install
 
 ```shell
-/plugin marketplace add ./
+/plugin marketplace add muitneliss/ymir
 /plugin install ymir@ymir
 /reload-plugins
 ```


### PR DESCRIPTION
## Summary
- Replace the local `Try it locally` README section with an `Install` section
- Use the GitHub marketplace shorthand `/plugin marketplace add muitneliss/ymir` instead of `./`

## Test plan
- [ ] Confirm `/plugin marketplace add muitneliss/ymir` resolves to the repo's `.claude-plugin/marketplace.json`
- [ ] Confirm `/plugin install ymir@ymir` then `/ymir init for this project` works end-to-end