### PR TITLE
ci: sync marketplace manifest version via release-please

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "ymir",
+  "version": "0.3.0",
   "owner": {
     "name": "articalam",
     "email": "lamhiep16@gmail.com"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,11 @@
           "type": "json",
           "path": "plugins/ymir/.claude-plugin/plugin.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/marketplace.json",
+          "jsonpath": "$.version"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Add root `version` field to `.claude-plugin/marketplace.json` (currently omitted → every commit counted as a new marketplace version).
- Wire `.claude-plugin/marketplace.json` `$.version` into release-please `extra-files`, so CI bumps the marketplace manifest version from the release tag on every release.
- Marketplace **plugin entry** version is intentionally NOT added: the [Claude Code marketplace docs](https://code.claude.com/docs/en/plugin-marketplaces) state plugin version resolves from `plugin.json` first and warn against duplicating it in the marketplace entry (the plugin.json value silently wins). `plugin.json` `$.version` is already release-please-synced.

Result: no version is hand-written. Release-please updates `plugin.json`, `version.txt`, and now `marketplace.json` from the tag, all via CI.

## Test plan
- [x] `claude plugin validate .` passes
- [x] JSON syntax valid for both files
- [ ] On next release PR, confirm release-please updates `$.version` in `.claude-plugin/marketplace.json` to match the tag