### PR TITLE
feat(ymir): codebase-first deep Socratic interview + native .claude/rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@
 [![release](https://img.shields.io/github/v/release/muitneliss/ymir?sort=semver)](https://github.com/muitneliss/ymir/releases)
 
 A Claude Code plugin marketplace + plugin that produces a **harness spec** for a
-repo — rules, lint, CI lint, wiki/context, and `CLAUDE.md`/`AGENT.md`.
+repo — rules (as native `.claude/rules/`), lint, CI lint, wiki/context, and
+`CLAUDE.md`/`AGENT.md`.
 
-Ymir does **not** generate application code. The interview step writes only a
-spec — it interviews you across a checklist of harness concerns, re-audits to
-confirm nothing is missing, and emits a spec under `.ymir/`:
+Ymir does **not** generate application code. It first **explores your codebase**,
+then runs a **deep Socratic interview** — per concern it probes the *why*,
+recommends a grounded option, and captures the rationale — re-audits for
+consistency, and emits a spec under `.ymir/`:
 
 - `.ymir/harness-profile.yaml` — your audited decisions (machine-readable).
 - `.ymir/harness-playbook.md` — step-by-step instructions an LLM follows to
@@ -58,10 +60,14 @@ Then: `/ymir init for this project`
 
 ## Status
 
-`v0.3.0`. Ymir runs a 3-step flow: a checklist-driven socratic interview, a
-re-audit gate, and a spec emitted to `.ymir/` (`harness-profile.yaml` +
-`harness-playbook.md`); `ymir apply` then generates the harness from that spec
-(with backups + `ymir revert`). The spec's per-concern playbook sections live in
-`plugins/ymir/templates/playbook/`. The **wiki / context** section drives the
-bundled wiki tooling (`plugins/ymir/wiki-cli`, templates, and the PreToolUse hook
-that blocks hand-editing wiki docs). The `/ymir add context` (or `add wiki`) intent scaffolds the wiki directly, as before.
+`v0.4.0`. Ymir runs a codebase-first flow: it scans the repo, then runs a deep
+per-concern Socratic interview (probe *why* → recommend → confirm, capturing
+`why`/`findings`), a consistency + reflection gate, a spec-review gate, and a spec
+emitted to `.ymir/` (`harness-profile.yaml` + `harness-playbook.md`); `ymir apply`
+then generates the harness from that spec (with backups + `ymir revert`). The
+spec's per-concern playbook sections live in `plugins/ymir/templates/playbook/`;
+the interview engine is in `plugins/ymir/references/socratic-interview.md`. The
+**rules** concern emits native `.claude/rules/*.md`. The **wiki / context** section
+drives the bundled wiki tooling (`plugins/ymir/wiki-cli`, templates, and the
+PreToolUse hook that blocks hand-editing wiki docs). The `/ymir add context` (or
+`add wiki`) intent scaffolds the wiki directly, as before.

--- a/docs/superpowers/plans/2026-06-18-ymir-socratic-interview.md
+++ b/docs/superpowers/plans/2026-06-18-ymir-socratic-interview.md
@@ -1,0 +1,638 @@
+# Ymir Socratic Interview Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn ymir's harness interview from a schema-driven form-fill into a codebase-first, deep Socratic dialogue that captures the *why*, checks cross-concern consistency, and emits native `.claude/rules/` for the rules concern.
+
+**Architecture:** Edit the *interview half* of one skill. Move the detailed interview mechanics into a new bundled reference doc; keep `SKILL.md` lean and pointing to it. Bump the profile schema to v2 (per-concern `why`/`findings`/`alternatives_considered`; `rules` becomes a `files[]` list targeting `.claude/rules/`). `ymir apply`/`revert` stay intact except for accepting a directory-valued `Target` for rules.
+
+**Tech Stack:** Markdown skill files + YAML profile schema (prose/config, not compiled code). No test framework — verification is `rg`/`grep` structural checks plus a documented manual dry-run protocol (the skill is executed interactively by Claude).
+
+**Spec:** `docs/superpowers/specs/2026-06-18-ymir-socratic-interview-design.md`
+
+## Global Constraints
+
+- The interview steps write **only** `.ymir/harness-profile.yaml` and `.ymir/harness-playbook.md` (spec-only). The single exception is the wiki-only intent (`ymir add context`/`ymir add wiki`), unchanged.
+- The **five concerns are fixed** (rules, lint, ci, wiki, claude_md) + foundation item 0 (project/techstack). Never drop, add, or reorder them.
+- Questions use `AskUserQuestion`, **one question per message**, multiple-choice preferred, open-ended where it surfaces the *why*.
+- `meta.spec_version` becomes `2`. `why` and `findings` are **required when a concern is `captured`**; `alternatives_considered` is recommended.
+- `rules` emits native **`.claude/rules/<name>.md`** files with optional `paths:` YAML frontmatter (omit = always-on). No `docs/rules.md`. `CLAUDE.md` must **not** point at `.claude/rules/` (auto-discovered).
+- `ymir apply`/`ymir revert` mechanics are unchanged **except** the playbook `**Target:**` parser must accept a directory (`.claude/rules/`) for the rules concern.
+- Git: commit per task. **Do NOT add a co-authored trailer** (user rule). Work in place in the current worktree.
+- Plugin root at runtime is `${CLAUDE_PLUGIN_ROOT}` = `plugins/ymir/`.
+
+---
+
+### Task 1: Schema v2 — `harness-profile.schema.md`
+
+**Files:**
+- Modify: `plugins/ymir/templates/harness-profile.schema.md`
+
+**Interfaces:**
+- Produces (consumed by Tasks 3 & 4): `meta.spec_version: 2`; per-concern `why` (string, required when captured), `findings` (string, required when captured), `alternatives_considered` (list, optional); `rules.files[]` where each entry is `{name: string, paths?: string[], obey?: string[], avoid?: string[]}`.
+
+- [ ] **Step 1: Write the verification check (expect FAIL)**
+
+Run:
+```bash
+rg -n "spec_version.*\b2\b|files\[\]|alternatives_considered" plugins/ymir/templates/harness-profile.schema.md
+```
+Expected: no matches (exit 1) — the schema is still v1.
+
+- [ ] **Step 2: Bump `spec_version` and add the rationale fields**
+
+In the "Top level" table, change the `meta.spec_version` row note to:
+```markdown
+| `meta.spec_version` | yes | integer; `2` for this schema |
+```
+
+Replace the "Required fields per concern" table so it reads:
+```markdown
+## Required fields per concern (only when `status: captured`)
+
+Every captured concern additionally requires `why` (string — the pain/goal the
+user expressed) and `findings` (string — what the Step 0 codebase scan saw + a
+verdict of `present-strong` / `present-weak` / `missing`). `alternatives_considered`
+(list) is recommended.
+
+| Concern | Required when captured (besides `why` + `findings`) |
+|---|---|
+| `rules` | at least one `files[]` entry; each entry needs a `name` and at least one of `obey[]` / `avoid[]` |
+| `lint` | `tool` |
+| `ci` | `provider`, `runs[]` |
+| `wiki` | `enabled`; and if `enabled: true`, then `collection` |
+| `claude_md` | `steer[]` |
+```
+
+- [ ] **Step 3: Document the `rules.files[]` shape and v1→v2 migration**
+
+Add this section after the table:
+```markdown
+## `rules.files[]` — one native `.claude/rules/` file per entry
+
+Each entry maps to `.claude/rules/<name>.md`:
+
+| Key | Required | Notes |
+|---|---|---|
+| `name` | yes | kebab-case; becomes the filename (`<name>.md`) |
+| `paths` | no | YAML list of globs (e.g. `["src/**/*.{ts,tsx}"]`). Omit for an always-on rule (loads at launch like `CLAUDE.md`). |
+| `obey` | — | conventions to follow (≥1 of `obey`/`avoid` required) |
+| `avoid` | — | patterns to ban (rendered as a "NEVER" list) |
+
+**v1 → v2 migration:** a v1 profile's flat `rules.obey`/`rules.avoid` upgrades to a
+single always-on `files[]` entry named `project-conventions` (no `paths`). Absent
+`why`/`findings` are treated as gaps to fill on resume; the next emit writes
+`spec_version: 2`.
+```
+
+- [ ] **Step 4: Replace the example block**
+
+Replace the existing `## Example` YAML with:
+```yaml
+meta:    { project: acme-api, generated_by: ymir, generated_at: 2026-06-18, spec_version: 2 }
+project: { language: typescript, runtime: bun, layer: backend, host: github }
+concerns:
+  rules:
+    status: captured
+    files:
+      - name: typescript-conventions      # → .claude/rules/typescript-conventions.md
+        paths: ["src/**/*.{ts,tsx}"]       # omit `paths` for an always-on rule
+        obey: [functional-core-imperative-shell, explicit-return-types]
+        avoid: [any, default-exports]
+      - name: testing
+        paths: ["**/*.test.ts"]
+        obey: [arrange-act-assert]
+    why: "encode the conventions Claude keeps violating, scoped so they load only when relevant"
+    findings: "present-weak — conventions implied in code but undocumented; no .claude/rules/"
+    alternatives_considered: [single-CLAUDE.md-section, docs/rules.md]
+  lint:
+    status: captured
+    tool: biome
+    strict: true
+    style: { indent: tab, quotes: single }
+    why: "catch real bugs + kill mixed quote styles without config overhead"
+    findings: "missing — no linter config; src/ mixes single+double quotes"
+    alternatives_considered: [eslint+prettier]
+  ci:        { status: captured, provider: github-actions, runs: [lint], why: "block PRs that fail lint", findings: "missing — no workflows" }
+  wiki:      { status: captured, enabled: true, collection: acme-api-wiki, why: "shared project knowledge for Claude", findings: "missing" }
+  claude_md: { status: captured, steer: [point-to-wiki, lint-before-commit], why: "steer Claude to wiki + lint gate", findings: "present-weak — thin CLAUDE.md" }
+```
+
+- [ ] **Step 5: Run the verification check (expect PASS)**
+
+Run:
+```bash
+rg -n "spec_version.*2|files\[\]|alternatives_considered|present-weak" plugins/ymir/templates/harness-profile.schema.md
+```
+Expected: matches in the table, migration note, and example.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/ymir/templates/harness-profile.schema.md
+git commit -m "feat(ymir): harness-profile schema v2 (why/findings/alternatives + rules.files[])"
+```
+
+---
+
+### Task 2: Interview engine reference doc — `references/socratic-interview.md`
+
+**Files:**
+- Create: `plugins/ymir/references/socratic-interview.md`
+
+**Interfaces:**
+- Produces (consumed by Task 4): the named flow `Step 1` points to — the 4-move loop, the per-concern probe bank, the greenfield fallback, the cross-concern consistency checklist (Step 2b), and the anti-patterns.
+
+- [ ] **Step 1: Verify the file does not yet exist (expect FAIL)**
+
+Run: `test -f plugins/ymir/references/socratic-interview.md && echo EXISTS || echo MISSING`
+Expected: `MISSING`
+
+- [ ] **Step 2: Create the reference doc with this exact content**
+
+Create `plugins/ymir/references/socratic-interview.md`:
+````markdown
+# Ymir Socratic Interview Engine
+
+This drives **Step 1** of `SKILL.md`. It turns the harness interview from a
+form-fill into a grounded dialogue. Read it before interviewing.
+
+## Cardinal rule — one question per message
+
+Every question is its own `AskUserQuestion` call. Ask one thing, then **stop and
+yield the floor**. Never batch questions "to be efficient" — batching freezes the
+conversation and you lose the ability to let an answer shape the next question.
+
+## Inputs from Step 0
+
+Before Step 1 you hold a **gap report**: for each concern a verdict of
+`present-strong`, `present-weak`, or `missing`, plus what was detected. Every
+question below is grounded in that finding — never ask something the scan already
+answered.
+
+## The per-concern loop (4 moves)
+
+Run this for each in-scope concern, in checklist order:
+
+1. **Probe the *why* (open, grounded).** Ask the purpose/pain behind the concern,
+   citing the finding. Not "which linter?" but "I see no linter and mixed quote
+   styles in `src/` — are you mainly after catching bugs, enforcing style, or
+   both?"
+2. **Recommend with trade-offs, recommendation first.** Offer 2-3 grounded
+   options, lead with your pick and why, invite challenge: "For TS/bun I'd pick
+   biome — one fast tool, near-zero config; trade-off vs eslint is fewer plugins.
+   Sound?"
+3. **Adaptive follow-up — only when needed.** Ask a follow-up *only* if the answer
+   reveals a gap, surprise, or contradiction. Otherwise go straight to confirm.
+   This is the friction ceiling that keeps it a dialogue, not an interrogation.
+4. **Confirm + record.** Write `decision`, `why`, `findings`,
+   `alternatives_considered` into `.ymir/harness-profile.yaml`, then advance.
+
+### Grounding by verdict
+
+- `present-strong` → confirm or tune what exists ("keep eslint as-is?").
+- `present-weak` → name the weakness and propose strengthening.
+- `missing` → propose adding — but apply **YAGNI**: if the user has no real need,
+  record `status: skipped` with a reason instead of forcing it.
+
+## Per-concern probe bank
+
+### project / techstack (item 0)
+Mostly **confirm** what Step 0 detected: "Detected TypeScript on bun, backend,
+GitHub — right?" Only ask cold if detection was empty.
+
+### rules → `.claude/rules/*.md` (special: scope probing)
+Rules become native Claude Code path-scoped rule files. After the *why*:
+- Elicit the conventions to **obey** and patterns to **avoid**.
+- For each rule (group), ask its **scope**: project-wide (always-on, no `paths`)
+  or scoped to files — "Does 'explicit return types' apply to all TS, or just
+  `src/api/**`?" Path-scoped rules load only when Claude reads a matching file.
+- Record one `files[]` entry per group: `{name, paths?, obey, avoid}`.
+
+### lint → linter config
+Why (bugs / style / both) → recommend a tool for the stack
+(biome / eslint / ruff / golangci-lint) with the trade-off → strictness →
+record `tool`, `strict`, `style`.
+
+### ci → CI workflow
+Why (gate PRs / catch regressions) → recommend the provider from `project.host`
+(github → github-actions) → what it runs (`runs: [lint]`) → record.
+
+### wiki / context
+Why (shared project knowledge for Claude) → enabled? → collection name →
+record `enabled`, `collection`.
+
+### claude_md → CLAUDE.md / AGENT.md
+Why (what should steer Claude here) → recommend steer points derived from
+concerns 2-4 (`lint-before-commit`, `point-to-wiki`). **Do NOT** add a
+`point-to-rules` steer — `.claude/rules/` auto-loads. Record `steer[]`.
+
+## Greenfield fallback
+
+If Step 0 found no signals (empty repo), there is no finding to cite. Ask the
+purpose directly, recommend sensible defaults for the declared stack, and record
+`findings: "missing — greenfield"`. This is the old onboarding behaviour, now a
+special case rather than the default.
+
+## Cross-concern consistency checklist (Step 2b)
+
+After the sweep, check these enumerated couplings. On a conflict, surface it
+plainly and **go back** to re-ask the implicated concern:
+
+- `lint.tool` ↔ `rules`: does a rule need enforcement the lint tool can't give? A
+  purely architectural rule is fine as a `.claude/rules/` file — but flag it if
+  the user expected lint to enforce it.
+- `rules` `paths` ↔ project layout: does each glob match real paths from Step 0?
+  Flag a glob that matches nothing (likely a typo or a dead directory).
+- `ci.provider` ↔ `project.host`: provider matches the host?
+- `lint.strict` ↔ `project.layer`/`runtime`: strictness sensible for the stack?
+- `claude_md.steer` ↔ concerns 2-4: steers toward the wiki/lint actually set up,
+  and does **not** redundantly point at `.claude/rules/`.
+
+## Anti-patterns (do not do these)
+
+- ❌ Asking "which tool?" with no *why* first — the bare field-question is the
+  shallow failure this engine exists to remove.
+- ❌ Batching multiple questions into one message.
+- ❌ Accepting the first answer without grounding it in the Step 0 finding.
+- ❌ Sweeping a concern the user has no need for instead of skipping it (YAGNI).
+````
+
+- [ ] **Step 3: Run the verification check (expect PASS)**
+
+Run:
+```bash
+test -f plugins/ymir/references/socratic-interview.md && \
+rg -c "4 moves|per-concern loop|Cross-concern consistency|Greenfield fallback|Anti-patterns" plugins/ymir/references/socratic-interview.md
+```
+Expected: file exists; count ≥ 5.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/ymir/references/socratic-interview.md
+git commit -m "feat(ymir): add Socratic interview engine reference doc"
+```
+
+---
+
+### Task 3: Playbook templates — Why/Findings block + rules → `.claude/rules/` + claude_md fix
+
+**Files:**
+- Modify: `plugins/ymir/templates/playbook/header.md`
+- Modify: `plugins/ymir/templates/playbook/rules.md`
+- Modify: `plugins/ymir/templates/playbook/lint.md`
+- Modify: `plugins/ymir/templates/playbook/ci.md`
+- Modify: `plugins/ymir/templates/playbook/wiki.md`
+- Modify: `plugins/ymir/templates/playbook/claude_md.md`
+
+**Interfaces:**
+- Consumes: `rules.files[]`, per-concern `why`/`findings`/`alternatives_considered` (Task 1).
+- Produces (consumed by Task 4 / `ymir apply`): each section starts with a `**Why / Findings:**` bullet; `rules.md` `**Target:**` is the `.claude/rules/` directory.
+
+- [ ] **Step 1: Verify the change is absent (expect FAIL)**
+
+Run: `rg -l "Why / Findings" plugins/ymir/templates/playbook/`
+Expected: no matches (exit 1).
+
+- [ ] **Step 2: Add a one-line note to `header.md`**
+
+Append to `plugins/ymir/templates/playbook/header.md`:
+```markdown
+>
+> Each section opens with a **Why / Findings** line recording the rationale and
+> what the codebase scan saw — context for the engineer/LLM; not an action.
+```
+
+- [ ] **Step 3: Rewrite `rules.md` to target `.claude/rules/`**
+
+Replace the entire contents of `plugins/ymir/templates/playbook/rules.md` with:
+```markdown
+## rules → `.claude/rules/` (native path-scoped rules)
+
+- **Why / Findings:** {{RULES_WHY}} — repo scan: {{RULES_FINDINGS}}. Considered: {{RULES_ALTERNATIVES}}.
+- **Target:** the `.claude/rules/` directory (one `<name>.md` file per `concerns.rules.files[]` entry)
+- **Inputs:** `concerns.rules.files[]` (each `{name, paths?, obey[], avoid[]}`)
+- **Steps:**
+  1. For each entry in `concerns.rules.files[]`, create `.claude/rules/<name>.md`.
+  2. If the entry has `paths`, add YAML frontmatter `--- \npaths:\n  - "<glob>"\n--- `
+     listing each glob; if it has no `paths`, write no frontmatter (always-on rule).
+  3. Add a top **"NEVER"** list — one bullet per `avoid[]` item.
+  4. Add sections (Naming, Error handling, Module boundaries) phrased from the
+     `obey[]` items.
+- **Verify:** every `files[]` entry has a matching `.claude/rules/<name>.md`; each
+  scoped entry's frontmatter `paths` matches the profile; every `avoid[]` item
+  appears in its file's NEVER list.
+```
+
+- [ ] **Step 4: Add the Why/Findings bullet to `lint.md`, `ci.md`, `wiki.md`, `claude_md.md`**
+
+In `lint.md`, insert as the first bullet (before `**Target:**`):
+```markdown
+- **Why / Findings:** {{LINT_WHY}} — repo scan: {{LINT_FINDINGS}}. Considered: {{LINT_ALTERNATIVES}}.
+```
+In `ci.md`, insert as the first bullet:
+```markdown
+- **Why / Findings:** {{CI_WHY}} — repo scan: {{CI_FINDINGS}}. Considered: {{CI_ALTERNATIVES}}.
+```
+In `claude_md.md`, insert as the first bullet (before `**Target:**`):
+```markdown
+- **Why / Findings:** {{CLAUDE_MD_WHY}} — repo scan: {{CLAUDE_MD_FINDINGS}}. Considered: {{CLAUDE_MD_ALTERNATIVES}}.
+```
+In `wiki.md`, insert directly under the `## wiki / context …` heading (before the `- **Target:**` line):
+```markdown
+- **Why / Findings:** {{WIKI_WHY}} — repo scan: {{WIKI_FINDINGS}}.
+```
+
+- [ ] **Step 5: Fix `claude_md.md` so it no longer points at rules**
+
+In `plugins/ymir/templates/playbook/claude_md.md` Step 2, replace the directive
+line so it drops `point-to-rules` and notes auto-loading:
+```markdown
+  2. For each `steer[]` point, add a short directive — e.g. `point-to-wiki`
+     links `wiki/SCHEMA.md`; `lint-before-commit` tells Claude to run the lint
+     command before commits. Do NOT add a pointer to `.claude/rules/` — Claude
+     Code auto-discovers those; a `point-to-rules` steer is redundant.
+```
+
+- [ ] **Step 6: Run the verification check (expect PASS)**
+
+Run:
+```bash
+rg -c "Why / Findings" plugins/ymir/templates/playbook/*.md   # expect 5 files
+rg -n "\.claude/rules/" plugins/ymir/templates/playbook/rules.md
+rg -n "point-to-rules" plugins/ymir/templates/playbook/claude_md.md   # expect: only the "Do NOT" line
+```
+Expected: `Why / Findings` in all 5 concern templates; `rules.md` targets `.claude/rules/`; `claude_md.md` only mentions `point-to-rules` in the prohibition.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add plugins/ymir/templates/playbook/
+git commit -m "feat(ymir): playbook Why/Findings blocks + rules targets .claude/rules/"
+```
+
+---
+
+### Task 4: Rewrite the interview half of `SKILL.md` (Steps 0–5)
+
+**Files:**
+- Modify: `plugins/ymir/SKILL.md` (the checklist + Steps 1–4 region, currently lines ~65–137; and the `line 81` premise)
+
+**Interfaces:**
+- Consumes: the reference doc (Task 2), schema v2 (Task 1), playbook templates (Task 3).
+- Produces: the user-facing flow. Leaves the `## Applying the spec` and `## Reverting an apply` sections (and `## Boundaries`) intact, except the one boundary wording about rules.
+
+- [ ] **Step 1: Verify the new flow is absent (expect FAIL)**
+
+Run: `rg -n "Understand the project|socratic-interview.md|Spec-review gate" plugins/ymir/SKILL.md`
+Expected: no matches (exit 1).
+
+- [ ] **Step 2: Replace the codebase premise (current `line 81`)**
+
+In the `## Step 1 …` region, replace:
+```markdown
+The user does not hand-write code, so Ymir cannot infer the stack from files.
+```
+with:
+```markdown
+Ymir explores the codebase FIRST (Step 0) and grounds every question in what it
+found. Only when the repo has no usable signals does it fall back to asking cold.
+```
+
+- [ ] **Step 3: Replace Steps 1–4 with the new Steps 0–5**
+
+Replace the whole region from `## Step 1 — Checklist-driven interview (socratic)` through the end of `## Step 4 — Offer to apply (the full flow is init → apply)` with:
+
+````markdown
+## Step 0 — Understand the project (codebase-first)
+
+Before asking anything, scan the repo and build a **gap report**. Detect the
+foundation (language, runtime, layer, host) from manifests (`package.json`,
+`go.mod`, `pyproject.toml`, …), lockfiles, and the `.git` remote; and per concern
+detect current state + a verdict — `present-strong`, `present-weak`, or `missing`:
+
+- `rules`: existing `.claude/rules/*.md`, conventions docs, `.editorconfig`, a
+  `CLAUDE.md`/`AGENT.md` rules section.
+- `lint`: a linter config present? which tool? strict?
+- `ci`: workflows present? what do they run?
+- `wiki`: a docs/context/wiki dir already used for project knowledge?
+- `claude_md`: `CLAUDE.md`/`AGENT.md` present? what does it steer?
+
+Print a one-line-per-concern findings summary so the interview is visibly
+grounded. **Greenfield fallback:** if there are no usable signals, mark every
+concern `missing` and proceed to ask cold.
+
+## Step 1 — Per-concern Socratic interview
+
+Walk item 0 (techstack — mostly **confirm** what Step 0 detected) then each
+in-scope concern. For each concern run the 4-move engine — **probe why → recommend
+(2-3 trade-offs, recommendation first) → adaptive follow-up only when needed →
+confirm** — asking **one question per `AskUserQuestion` message**. The full engine,
+the per-concern probe bank, the rules scope-probing, and the greenfield phrasing
+live in `${CLAUDE_PLUGIN_ROOT}/references/socratic-interview.md` — read it before
+interviewing.
+
+- For `ymir init`, sweep the whole checklist; for a narrow action (e.g. `add
+  lint`), run item 0 (if unknown) plus that one concern.
+- The user may skip a concern → record `status: skipped` with a `reason`.
+- Write each answer into `.ymir/harness-profile.yaml` as you go, including
+  `why`, `findings`, and `alternatives_considered`. Field shape:
+  `${CLAUDE_PLUGIN_ROOT}/templates/harness-profile.schema.md`.
+
+## Step 2 — Consistency + re-audit (gate)
+
+Before emitting:
+
+1. **Required-field check** — every in-scope concern has its decision fields plus
+   `why` and `findings`. Anything missing → keep the concern `pending` and loop
+   back to ask exactly that.
+2. **Cross-concern consistency pass** — run the bounded checklist in
+   `references/socratic-interview.md` ("Cross-concern consistency checklist"). On a
+   conflict, surface it plainly and **go back** to re-ask the implicated concern.
+3. **Reflection gate** — print, per concern, `decision + one-line why` (with
+   `✅ captured` / `⏭️ skipped` / `❌ pending` markers) and ask: *"Does this reflect
+   your intent? Want to revisit any concern before I write the spec?"*
+
+**Do not proceed to Step 3 while any in-scope concern is `pending`, or before the
+user confirms the reflection summary.**
+
+## Step 3 — Emit the spec
+
+Assemble the playbook from the bundled per-concern templates — do not free-form it:
+
+1. Ensure `.ymir/harness-profile.yaml` reflects the final audited decisions
+   (`spec_version: 2`).
+2. Write `.ymir/harness-playbook.md`: start from
+   `${CLAUDE_PLUGIN_ROOT}/templates/playbook/header.md` (fill `{{PROJECT}}` and
+   `{{DATE}}`), then append one section per `captured` concern from
+   `${CLAUDE_PLUGIN_ROOT}/templates/playbook/<concern>.md`, filling every `{{...}}`
+   placeholder (including the `Why / Findings` block) from the profile. Omit
+   `skipped` concerns.
+3. Tell the user the spec is ready under `.ymir/`.
+
+(Spec-generation only — never write harness files here; `ymir apply` does that.)
+
+## Step 4 — Spec-review gate
+
+After emitting, before offering apply, ask the user to review the written files:
+
+> "Spec written to `.ymir/harness-profile.yaml` and `.ymir/harness-playbook.md`.
+> Please review them and tell me if you want any changes before I generate the
+> harness."
+
+Wait. On a change request, revisit the relevant concern, re-emit, and return to
+this gate. Only on approval proceed to Step 5.
+
+## Step 5 — Offer to apply (the full flow is init → apply)
+
+After the user approves the spec, **ask** (via `AskUserQuestion`) whether to
+generate it now:
+
+> "Generate the harness now with `ymir apply`?"
+
+- **Yes** → proceed into the "Applying the spec" flow below, in this same session.
+- **No** → tell the user they can run `ymir apply` whenever they're ready; stop here.
+
+For a narrow intent (e.g. `ymir add lint`), offer `ymir apply lint` — apply just
+that one concern. Never auto-run apply without a yes; apply writes files.
+````
+
+- [ ] **Step 4: Update the checklist intro + "How this skill works" references**
+
+In the `## The checklist` section, leave the table as-is (the five concerns are
+fixed). In the `## How this skill works` table row for `ymir init`, change its
+description to: `understand the codebase, sweep the checklist, audit, emit the spec`.
+
+In `## Boundaries`, replace the rules-related wording so it reflects
+`.claude/rules/`:
+```markdown
+- The `rules` concern emits native `.claude/rules/*.md` (path-scoped), not a
+  `docs/rules.md`; `CLAUDE.md` does not point at them (auto-discovered).
+```
+
+- [ ] **Step 5: Run the verification check (expect PASS)**
+
+Run:
+```bash
+rg -n "Step 0 — Understand the project|socratic-interview.md|Spec-review gate|spec_version: 2" plugins/ymir/SKILL.md
+rg -n "cannot infer the stack from files" plugins/ymir/SKILL.md   # expect: no matches
+```
+Expected: the new steps + reference pointer present; the old premise gone.
+
+- [ ] **Step 6: Cross-file consistency check**
+
+Run:
+```bash
+# every concern named in SKILL.md Step 0 has a playbook template
+for c in rules lint ci wiki claude_md; do test -f plugins/ymir/templates/playbook/$c.md || echo "MISSING $c"; done
+# the reference doc the skill points to exists
+test -f plugins/ymir/references/socratic-interview.md && echo OK
+```
+Expected: no `MISSING`; `OK`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add plugins/ymir/SKILL.md
+git commit -m "feat(ymir): codebase-first Socratic interview (Steps 0-5, consistency + gates)"
+```
+
+---
+
+### Task 5: Reframe docs — `README.md` + `plugin.json`
+
+**Files:**
+- Modify: `README.md`
+- Modify: `plugins/ymir/.claude-plugin/plugin.json`
+
+**Interfaces:**
+- Consumes: the final behaviour from Tasks 1–4. No downstream consumers.
+
+- [ ] **Step 1: Verify the reframe is absent (expect FAIL)**
+
+Run: `rg -n "codebase-first|\.claude/rules" README.md plugins/ymir/.claude-plugin/plugin.json`
+Expected: no matches (exit 1).
+
+- [ ] **Step 2: Update `plugin.json` description**
+
+Set the `description` field to:
+```json
+  "description": "Explores THIS project's codebase first, then runs a deep Socratic interview across a harness checklist (rules → .claude/rules/, lint, CI lint, wiki/context, CLAUDE.md), captures the rationale, re-audits for consistency, and emits a spec under .ymir/. 'ymir apply' then generates the harness (with backups + 'ymir revert'). Never writes application code.",
+```
+
+- [ ] **Step 3: Update the README Status/overview**
+
+In `README.md`, update the overview/status prose to state: ymir now (1) understands
+the codebase before interviewing, (2) interviews deeply per concern (why →
+recommend → confirm), capturing `why`/`findings`, and (3) emits `rules` as native
+`.claude/rules/*.md`. Keep it to 2-3 sentences; match the existing README voice.
+
+- [ ] **Step 4: Run the verification check (expect PASS)**
+
+Run: `rg -n "codebase|Socratic|\.claude/rules" README.md plugins/ymir/.claude-plugin/plugin.json`
+Expected: matches in both files.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md plugins/ymir/.claude-plugin/plugin.json
+git commit -m "docs(ymir): reframe as codebase-first deep-interview harness generator"
+```
+
+---
+
+### Task 6: Final consistency sweep + manual dry-run protocol
+
+**Files:**
+- None modified (verification only). Optionally Create: a throwaway fixture under `$TMPDIR`.
+
+**Interfaces:**
+- Consumes: all prior tasks.
+
+- [ ] **Step 1: Automated cross-file consistency sweep**
+
+Run:
+```bash
+# spec_version 2 is consistent across schema + SKILL
+rg -n "spec_version" plugins/ymir/templates/harness-profile.schema.md plugins/ymir/SKILL.md
+# no stray docs/rules.md as a TARGET anywhere (only allowed as an "alternative considered")
+rg -n "Target:.*docs/rules.md" plugins/ymir/templates/playbook/ || echo "OK: no docs/rules.md target"
+# SKILL points to the reference doc and it exists
+rg -q "references/socratic-interview.md" plugins/ymir/SKILL.md && test -f plugins/ymir/references/socratic-interview.md && echo "OK: reference wired"
+```
+Expected: `spec_version: 2` in both; `OK: no docs/rules.md target`; `OK: reference wired`.
+
+- [ ] **Step 2: Manual dry-run — existing repo (present-weak)**
+
+In a scratch dir with a `package.json` (TS) and a loose `eslint` config, mentally
+walk `ymir init`: Step 0 must report `lint: present-weak`; Move 2 must *recommend
+keep/tune eslint* (not propose biome blind); the emitted profile must contain
+`lint.why` and `lint.findings`. Record PASS/FAIL in the commit message of any
+follow-up fix.
+
+- [ ] **Step 3: Manual dry-run — greenfield**
+
+In an empty dir, walk `ymir init`: every concern `missing`; the engine asks cold
+using the fallback phrasing; `findings` reads `"missing — greenfield"`.
+
+- [ ] **Step 4: Manual dry-run — rules scope + consistency**
+
+Walk the `rules` concern with one always-on group and one `paths`-scoped group:
+the profile must produce two `files[]` entries; only the scoped one has `paths`.
+Then seed a conflict (a rule that needs enforcement biome lacks) and confirm Step 2b
+flags it and loops back.
+
+- [ ] **Step 5: Record results**
+
+If any dry-run reveals a gap, fix it inline in the relevant task's files and
+re-commit. If all pass, no commit needed — note completion to the user.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Step 0 codebase-first (Task 4 Step 3) ✓; per-concern engine (Tasks 2, 4) ✓; capture why/findings/alternatives (Tasks 1, 3, 4) ✓; consistency + go-back + reflection gate + spec-review gate (Tasks 2, 4) ✓; `rules` → `.claude/rules/` (Tasks 1, 3) ✓; lean SKILL + reference doc (Tasks 2, 4) ✓; schema v2 + migration (Task 1) ✓; docs reframe (Task 5) ✓; apply directory-Target accommodation (noted in Task 3 rules.md Target + Open items — execution surfaces it during dry-run Task 6 Step 4).
+- **Placeholder scan:** the `{{...}}` tokens are intentional playbook template syntax; no `TBD`/`TODO`/"implement later" remain.
+- **Type consistency:** `files[]` entry shape `{name, paths?, obey, avoid}` is identical across Task 1 (schema), Task 3 (`rules.md` Steps), and Task 4 (Step 1 instructions). `why`/`findings`/`alternatives_considered` names match across all tasks.
+- **Note:** `ymir apply`'s `**Target:**` parser accepting a directory for `.claude/rules/` is an Open Item from the spec — if Task 6 Step 4 shows apply mishandling the directory target, add a follow-up task to extend the parser (kept out of scope here per the spec's "apply unchanged except minimal accommodation").

--- a/docs/superpowers/specs/2026-06-18-ymir-socratic-interview-design.md
+++ b/docs/superpowers/specs/2026-06-18-ymir-socratic-interview-design.md
@@ -69,7 +69,8 @@ a *bounded, enumerated* checklist, not open-ended magic.
 ## Non-Goals (YAGNI)
 
 - No change to `ymir apply` / `ymir revert` mechanics, or the wiki CLI / hook /
-  templates.
+  templates — **except** the minimal accommodation for the `rules` concern's
+  directory-valued `**Target:**` (`.claude/rules/`; see Open items).
 - No new automated test framework. Verification is a schema self-check plus
   documented dry-run scenarios.
 - No dropping, adding, or reordering concerns — the five stay fixed.
@@ -88,6 +89,8 @@ a *bounded, enumerated* checklist, not open-ended magic.
 | Capture rationale | **Fully structured** — `why` / `findings` / `alternatives_considered` per concern in YAML **and** playbook. Bump `spec_version` to 2. |
 | Structural fidelity | **Full set** — cross-concern consistency + go-back, a reflection gate, and a spec-review gate. |
 | Edit structure | **Lean `SKILL.md` + a new `references/socratic-interview.md`** reference doc holding the engine detail. |
+| `rules` output location | Generate native **`.claude/rules/*.md`** (Claude Code path-scoped rules), **not** `docs/rules.md`. Each rule group = one file with optional `paths:` frontmatter globs (omit `paths` = always-on, same priority as `CLAUDE.md`). Path-scoped rules lazy-load when Claude reads a matching file. |
+| `rules` ↔ `claude_md` | **No overlap** — they write to different locations (`.claude/rules/*.md` vs `CLAUDE.md`). `CLAUDE.md` does **not** point at the rules (Claude Code auto-discovers `.claude/rules/`). Both concerns stay in the fixed five. |
 
 ## Architecture
 
@@ -124,8 +127,8 @@ steps are marked ▶.
 |---|---|
 | `plugins/ymir/SKILL.md` | Rewrite Steps 0–4 into the codebase-first Socratic flow; **lean** — step structure + pointers, not full mechanics. Replace `line 81` ("cannot infer from files") with the codebase-first premise. |
 | `plugins/ymir/references/socratic-interview.md` | **NEW.** The engine: the 4-move per-concern loop, a per-concern probe bank, the recommendation pattern, the cross-concern consistency checklist, the greenfield fallback, and an explicit anti-pattern callout. |
-| `plugins/ymir/templates/harness-profile.schema.md` | Schema **v2**: add `why` / `findings` / `alternatives_considered` per concern; bump `spec_version`. |
-| `plugins/ymir/templates/playbook/header.md` + each `*.md` | Add a non-breaking `**Why / Findings:**` block per concern section. |
+| `plugins/ymir/templates/harness-profile.schema.md` | Schema **v2**: add `why` / `findings` / `alternatives_considered` per concern; bump `spec_version`. Replace `rules`' flat `obey`/`avoid` with a `files[]` list (each `{name, paths?, obey, avoid}`). |
+| `plugins/ymir/templates/playbook/header.md` + each `*.md` | Add a non-breaking `**Why / Findings:**` block per concern section. **`rules.md`:** change `**Target:**` from `docs/rules.md` to the `.claude/rules/` directory; `**Steps:**` iterate `files[]`, writing one `.claude/rules/<name>.md` each (with `paths:` frontmatter when present); `**Verify:**` each file exists and any `avoid` items appear. |
 | `README.md`, `plugins/ymir/.claude-plugin/plugin.json` | Light reframe: codebase-first + deeper interview. Still spec-only. |
 
 ### Component 1 — Step 0: understand the project (codebase-first)
@@ -136,7 +139,7 @@ Before any question, ymir scans the repo and forms a **gap report**. It detects:
   repo host — from manifests (`package.json`, `go.mod`, `pyproject.toml`, …),
   lockfiles, and the `.git` remote.
 - **Per concern, current state + quality verdict:**
-  - `rules`: existing conventions docs, `.editorconfig`, an existing `CLAUDE.md`/`AGENT.md` rules section.
+  - `rules`: existing `.claude/rules/*.md`, conventions docs, `.editorconfig`, an existing `CLAUDE.md`/`AGENT.md` rules section.
   - `lint`: a linter config present? which tool? strict?
   - `ci`: workflows present? what do they run? provider inferred from host.
   - `wiki`: any docs/context/wiki directory already used for project knowledge?
@@ -186,6 +189,13 @@ cold question.
 
 - A **per-concern probe bank**: the grounded *why*-question and the recommendation
   skeleton for each of `rules`/`lint`/`ci`/`wiki`/`claude_md`.
+- **`rules`-specific depth — scope probing.** Because each rule becomes a
+  `.claude/rules/<name>.md` file with optional `paths:` globs, the `rules` engine
+  adds a scope move: for each rule (group), ask whether it is project-wide
+  (always-on, no `paths`) or scoped to certain files (e.g. *"Does
+  'explicit return types' apply to all TS, or just `src/api/**`?"*). This is the
+  native context-efficiency win — path-scoped rules only load when Claude reads a
+  matching file — and it is a natural deepening the old flat `obey`/`avoid` lacked.
 - The **greenfield fallback** phrasing (no finding to cite → ask the purpose
   directly).
 - An explicit **anti-pattern** callout: *"DON'T just ask 'which tool?' — that bare
@@ -201,15 +211,20 @@ Runs after the per-concern sweep, in three parts:
   loops back to ask exactly that.
 - **(b) Cross-concern consistency pass (NEW, bounded).** A finite, enumerated
   checklist of known couplings — not a general reasoner:
-  - `lint.tool` ↔ `rules`: do `obey`/`avoid` rules need enforcement the chosen
-    tool cannot provide? (e.g. an architectural rule biome cannot lint → flag that
-    it belongs in the rules doc / `CLAUDE.md`, not expected from lint).
+  - `lint.tool` ↔ `rules`: do any rule items need enforcement the chosen lint tool
+    cannot provide? A purely architectural rule lint can't catch is fine — it lives
+    as a `.claude/rules/` file — but flag it if the user expected lint to enforce
+    something only a rule file can state.
+  - `rules` `paths` ↔ project layout: each rule's globs should match real paths
+    seen in the Step 0 scan; flag a glob that matches nothing (likely a typo or a
+    rule scoped to a directory that doesn't exist).
   - `ci.provider` ↔ `project.host`: does the provider match the repo host
     (github → github-actions)?
   - `lint.strict` ↔ `project.layer`/`runtime`: is the strictness sensible for the
     declared stack?
-  - `claude_md.steer` ↔ concerns 1–4: does it point at the rules/wiki/lint that
-    were actually set up?
+  - `claude_md.steer` ↔ concerns 2–4: does `CLAUDE.md` steer toward the wiki and
+    lint-before-commit that were actually set up? It must **not** redundantly point
+    at `.claude/rules/` (those auto-load) — flag a `steer` that does.
   On a conflict, ymir surfaces it plainly and **goes back** to re-ask the specific
   concern (the "be flexible" mechanism).
 - **(c) Reflection gate (NEW).** Replaces the bare coverage table. Print, per
@@ -235,7 +250,28 @@ concerns:
     why: "catch real bugs + kill mixed quote styles without config overhead"
     findings: "missing — no linter config; src/ mixes single+double quotes"
     alternatives_considered: [eslint+prettier]
+  rules:
+    status: captured
+    files:
+      - name: typescript-conventions      # → .claude/rules/typescript-conventions.md
+        paths: ["src/**/*.{ts,tsx}"]       # omit `paths` for an always-on rule
+        obey: [explicit-return-types, functional-core-imperative-shell]
+        avoid: [any, default-exports]
+      - name: testing
+        paths: ["**/*.test.ts"]
+        obey: [arrange-act-assert]
+    why: "encode the conventions Claude keeps violating, scoped so they load only when relevant"
+    findings: "present-weak — conventions implied in code but undocumented; no .claude/rules/"
+    alternatives_considered: [single-CLAUDE.md-section, docs/rules.md]
 ```
+
+The `rules` concern emits one `.claude/rules/<name>.md` per `files[]` entry, each
+with that entry's `paths:` as YAML frontmatter (omitted when absent → always-on)
+and the `obey`/`avoid` items as the rule body. Accordingly, the
+`templates/playbook/rules.md` section's `**Target:**` changes from `docs/rules.md`
+to the **`.claude/rules/`** directory, and its `**Steps:**` iterate `files[]`. The
+`rules` required-when-`captured` fields become **at least one `files[]` entry**
+(each with `obey`/`avoid` content) plus `why`/`findings`.
 
 `harness-playbook.md` per-concern sections gain a `**Why / Findings:**` block
 directly under the heading, filled from the profile via the existing `{{...}}`
@@ -313,10 +349,16 @@ ymir's skill behaviour is prose, so verification is lightweight and explicit:
    - Greenfield empty repo → fallback path, asks cold, `findings: missing`.
    - Seeded cross-concern conflict (a rule needing a plugin biome lacks) → the
      consistency pass flags it and loops back.
+   - `rules` with a scoped entry → ymir asks the scope question, emits
+     `.claude/rules/<name>.md` with a `paths:` frontmatter, and an always-on entry
+     emits a file with no frontmatter.
 3. **Backward-compat check:** a v1 profile loads, resumes, and upgrades to v2 on
-   next emit without data loss.
+   next emit without data loss. A v1 `rules.obey/avoid` (flat) upgrades to a single
+   always-on `files[]` entry.
 4. **Apply non-regression:** `ymir apply` against a v2 spec still parses
-   `Target`/`Verify` correctly and ignores the `Why / Findings` block.
+   `Target`/`Verify` and executes `Steps`, ignoring the `Why / Findings` block; the
+   `rules` concern writes the `.claude/rules/` directory and `ymir revert` cleanly
+   undoes it.
 
 ## Boundaries (unchanged, and stronger)
 
@@ -336,4 +378,10 @@ ymir's skill behaviour is prose, so verification is lightweight and explicit:
   (`{state, detail}`) — default to a prose string for YAGNI; revisit if the
   consistency pass needs structured access.
 - The precise enumerated entries of the cross-concern consistency checklist
-  (finalize in the plan; the four couplings above are the seed set).
+  (finalize in the plan; the couplings above are the seed set).
+- `ymir apply` granularity for the multi-file `.claude/rules/` target: per-file
+  keep/merge/overwrite vs whole-directory (finalize in the plan; backups must still
+  yield a clean `ymir revert`). The playbook `**Target:**` parser must accept a
+  directory target, not only a single file path.
+- Default rule-file `name` derivation when the user doesn't supply one (e.g. from
+  the concern/topic, kebab-cased) — finalize in the plan.

--- a/docs/superpowers/specs/2026-06-18-ymir-socratic-interview-design.md
+++ b/docs/superpowers/specs/2026-06-18-ymir-socratic-interview-design.md
@@ -1,0 +1,339 @@
+# Ymir Socratic Interview — Design
+
+Date: 2026-06-18
+Status: Approved (design); implementation pending
+Branch: `worktree-feat+ymir-harness-spec`
+
+## Background
+
+Ymir's `SKILL.md` Step 1 is labelled "Checklist-driven interview (socratic)"
+(`SKILL.md:79`), but it is structurally a **form-fill**, not a dialogue. It walks
+a fixed six-item checklist (item 0 techstack, then concerns 1–5) and, for each,
+asks the schema's required fields ("which lint tool?", "which CI provider?").
+The re-audit gate (`SKILL.md:93–105`) loops back only on **field presence**, not
+on the quality, depth, or internal consistency of the answers.
+
+Two concrete problems follow:
+
+1. **The interview is shallow.** "Socratic" here means only *one decision at a
+   time*; it never probes *why* the user wants a choice, never recommends with
+   trade-offs, and never adapts the next question to the last answer. The user's
+   own words: it "feels like just overall questions."
+2. **It refuses to read the codebase.** `SKILL.md:81` asserts: *"The user does
+   not hand-write code, so Ymir cannot infer the stack from files."* This
+   contradicts the intended flow — *understand the codebase → propose the harness
+   the project needs → apply it.*
+
+This design transplants the **confirmed** behaviours of the Superpowers
+`brainstorming` skill's interview engine into ymir, while preserving ymir's
+identity: spec-only output, the fixed five-concern checklist, `AskUserQuestion`,
+and the untouched `apply`/`revert` machinery.
+
+Confirmed brainstorming behaviours we adopt (verified against
+`skills/brainstorming/SKILL.md`, not just the research deep-dive):
+
+- One question per message; the agent yields the floor after each
+  (`SKILL.md:72,135`).
+- Explore project context **before** asking anything (`SKILL.md:24,67`).
+- Anchor questions to *purpose / constraints / success criteria*
+  (`SKILL.md:73`).
+- Propose 2–3 approaches with trade-offs, **lead with a recommendation and
+  explain why** (`SKILL.md:77–79`).
+- Be flexible — **go back and clarify when something doesn't make sense**
+  (`SKILL.md:140`).
+- A human review gate on the written artefact before the next phase
+  (`SKILL.md:122–126`).
+
+Deliberately **not** treated as gospel (these are research interpretation, not
+in the source): a named six-step loop, an internal "bucket-tracking" mechanism,
+a generic "contradiction detector." Where we add consistency checking we make it
+a *bounded, enumerated* checklist, not open-ended magic.
+
+## Goals
+
+- **Codebase-first.** Ymir explores the repo before interviewing and produces a
+  per-concern gap report. Greenfield repos fall back to today's ask-cold
+  behaviour.
+- **Keep all five concerns**, but make each one a deep, grounded exchange instead
+  of a single field-question.
+- **Per-concern engine:** probe *why* → recommend (grounded, 2–3 trade-offs,
+  recommendation first) → adaptive follow-up only when needed → confirm.
+- **Capture the rationale durably** — `why`, `findings`, `alternatives_considered`
+  per concern — in `harness-profile.yaml` (v2) and `harness-playbook.md`.
+- **Add structural discipline:** a bounded cross-concern consistency pass with
+  go-back, a reflection gate before emitting, and a spec-review gate before
+  `apply`.
+- **Keep `SKILL.md` lean** by moving the detailed engine into a bundled
+  reference doc (mirrors how `brainstorming` uses `visual-companion.md`).
+
+## Non-Goals (YAGNI)
+
+- No change to `ymir apply` / `ymir revert` mechanics, or the wiki CLI / hook /
+  templates.
+- No new automated test framework. Verification is a schema self-check plus
+  documented dry-run scenarios.
+- No dropping, adding, or reordering concerns — the five stay fixed.
+- The skill stays **spec-only** (the wiki-only intent exception is unchanged).
+- No generic contradiction detector; cross-concern consistency is an explicit,
+  finite checklist of known couplings.
+- No domain presets / per-stack tailoring beyond what the codebase scan reveals.
+
+## Decisions (resolved during brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Target scenario | **Both** — read the codebase if present, else greenfield fallback. Understanding the codebase happens **before** the interview. |
+| Codebase → checklist | Keep the **fixed 5 concerns**; run **gap-analysis per concern** and propose a deeper, grounded fix (not "which tool?"). |
+| Per-concern depth | **Probe why → recommend (2–3 trade-offs, recommendation first) → adaptive follow-up → confirm** (~2–4 turns, adaptive). |
+| Capture rationale | **Fully structured** — `why` / `findings` / `alternatives_considered` per concern in YAML **and** playbook. Bump `spec_version` to 2. |
+| Structural fidelity | **Full set** — cross-concern consistency + go-back, a reflection gate, and a spec-review gate. |
+| Edit structure | **Lean `SKILL.md` + a new `references/socratic-interview.md`** reference doc holding the engine detail. |
+
+## Architecture
+
+The interview half of ymir grows from three steps to six. Only the **interview**
+side changes; `apply`/`revert` (`SKILL.md:139–211`) are untouched. New or changed
+steps are marked ▶.
+
+```
+▶ Step 0  Understand the project (codebase-first)
+            scan repo → per-concern gap report: present-strong / present-weak / missing
+            greenfield fallback: no signals → all "missing", ask cold (today's behaviour)
+            present a short findings summary before the first question
+
+▶ Step 1  Per-concern Socratic interview   (item 0 techstack, then the 5 concerns)
+            for each concern, run the 4-move engine (detailed in the reference doc):
+              probe why → recommend → adaptive follow-up → confirm
+            write decision + why + findings + alternatives_considered to the profile as you go
+            techstack (item 0): mostly CONFIRM what was detected, not ask cold
+
+▶ Step 2  Consistency + re-audit gate
+            (a) required-field check (today's behaviour)
+            (b) NEW bounded cross-concern consistency pass → on conflict, surface + go back
+            (c) NEW reflection gate: per-concern "decision + one-line why", "revisit anything?"
+
+  Step 3  Emit the spec    (harness-profile.yaml v2 + harness-playbook.md with Why/Findings)
+
+▶ Step 4  Spec-review gate    NEW: "Spec written to .ymir/. Review before I generate?" → wait
+  Step 5  Offer apply         (today's apply/revert flow — unchanged)
+```
+
+### File layout (Approach A)
+
+| File | Change |
+|---|---|
+| `plugins/ymir/SKILL.md` | Rewrite Steps 0–4 into the codebase-first Socratic flow; **lean** — step structure + pointers, not full mechanics. Replace `line 81` ("cannot infer from files") with the codebase-first premise. |
+| `plugins/ymir/references/socratic-interview.md` | **NEW.** The engine: the 4-move per-concern loop, a per-concern probe bank, the recommendation pattern, the cross-concern consistency checklist, the greenfield fallback, and an explicit anti-pattern callout. |
+| `plugins/ymir/templates/harness-profile.schema.md` | Schema **v2**: add `why` / `findings` / `alternatives_considered` per concern; bump `spec_version`. |
+| `plugins/ymir/templates/playbook/header.md` + each `*.md` | Add a non-breaking `**Why / Findings:**` block per concern section. |
+| `README.md`, `plugins/ymir/.claude-plugin/plugin.json` | Light reframe: codebase-first + deeper interview. Still spec-only. |
+
+### Component 1 — Step 0: understand the project (codebase-first)
+
+Before any question, ymir scans the repo and forms a **gap report**. It detects:
+
+- **Foundation (item 0):** language(s), runtime, layer (frontend/backend/both),
+  repo host — from manifests (`package.json`, `go.mod`, `pyproject.toml`, …),
+  lockfiles, and the `.git` remote.
+- **Per concern, current state + quality verdict:**
+  - `rules`: existing conventions docs, `.editorconfig`, an existing `CLAUDE.md`/`AGENT.md` rules section.
+  - `lint`: a linter config present? which tool? strict?
+  - `ci`: workflows present? what do they run? provider inferred from host.
+  - `wiki`: any docs/context/wiki directory already used for project knowledge?
+  - `claude_md`: `CLAUDE.md`/`AGENT.md` present? what does it currently steer?
+
+Each concern gets a verdict: **`present-strong`** (exists and is healthy),
+**`present-weak`** (exists but thin/loose/outdated), or **`missing`**.
+
+**Greenfield fallback.** If the repo has no usable signals (empty or near-empty),
+every concern is `missing` and ymir proceeds to ask cold — this preserves the
+original onboarding behaviour as a special case rather than the default.
+
+Ymir presents a brief findings summary (one line per concern) before the first
+question, so the user sees what ymir found and the interview is visibly grounded.
+
+### Component 2 — Step 1: the per-concern Socratic engine
+
+Detailed in `references/socratic-interview.md`; `SKILL.md` Step 1 points to it.
+For each concern, in checklist order, ymir runs four moves. **Each move that asks
+the user is its own single-question `AskUserQuestion` message** (one question at a
+time — the linchpin).
+
+- **Move 1 — Probe the *why* (open, grounded in the finding).** Not "which
+  linter?" but, e.g.: *"I see no linter config and mixed quote styles across
+  `src/` — what are you mainly after: catch real bugs, enforce consistent style,
+  or both?"* The finding makes the question concrete and shows ymir read the
+  repo.
+- **Move 2 — Recommend with trade-offs, recommendation first.** Grounded in the
+  stack + finding + the stated *why*, ymir proposes 2–3 options, leads with its
+  pick and the reasoning, and invites challenge: *"For a TS/bun backend I'd pick
+  **biome** — one fast tool for lint+format, near-zero config; trade-off vs
+  eslint is fewer niche plugins. Alternative: eslint+prettier if you need
+  specific plugins. I'd go biome — sound?"*
+- **Move 3 — Adaptive follow-up, only when needed.** Ask a follow-up **only** if
+  the answer reveals a gap, a surprise, or a contradiction (e.g. the user wants
+  strict enforcement but the codebase has patterns that would break under it).
+  Otherwise skip straight to confirm. This is the friction ceiling that keeps the
+  exchange a dialogue, not an interrogation.
+- **Move 4 — Confirm + record.** Write `decision` + `why` + `findings` +
+  `alternatives_considered` into `.ymir/harness-profile.yaml`, then advance.
+
+Item 0 (techstack) runs first and is mostly **confirmation** of what Step 0
+detected ("Detected TypeScript on bun, backend, GitHub — correct?") rather than a
+cold question.
+
+`references/socratic-interview.md` additionally specifies:
+
+- A **per-concern probe bank**: the grounded *why*-question and the recommendation
+  skeleton for each of `rules`/`lint`/`ci`/`wiki`/`claude_md`.
+- The **greenfield fallback** phrasing (no finding to cite → ask the purpose
+  directly).
+- An explicit **anti-pattern** callout: *"DON'T just ask 'which tool?' — that bare
+  field-question is the shallow failure this engine exists to remove."*
+
+### Component 3 — Step 2: consistency + re-audit gate
+
+Runs after the per-concern sweep, in three parts:
+
+- **(a) Required-field check** — unchanged from today: every in-scope concern must
+  have its machine-decision fields (`lint.tool`, `ci.provider`+`runs`, etc.) plus,
+  now, `why` and `findings`. Anything missing keeps the concern `pending` and
+  loops back to ask exactly that.
+- **(b) Cross-concern consistency pass (NEW, bounded).** A finite, enumerated
+  checklist of known couplings — not a general reasoner:
+  - `lint.tool` ↔ `rules`: do `obey`/`avoid` rules need enforcement the chosen
+    tool cannot provide? (e.g. an architectural rule biome cannot lint → flag that
+    it belongs in the rules doc / `CLAUDE.md`, not expected from lint).
+  - `ci.provider` ↔ `project.host`: does the provider match the repo host
+    (github → github-actions)?
+  - `lint.strict` ↔ `project.layer`/`runtime`: is the strictness sensible for the
+    declared stack?
+  - `claude_md.steer` ↔ concerns 1–4: does it point at the rules/wiki/lint that
+    were actually set up?
+  On a conflict, ymir surfaces it plainly and **goes back** to re-ask the specific
+  concern (the "be flexible" mechanism).
+- **(c) Reflection gate (NEW).** Replaces the bare coverage table. Print, per
+  concern, `decision + one-line why`, then ask: *"Does this reflect your intent?
+  Want to revisit any concern before I write the spec?"* Step 3 runs only after
+  the user confirms. The `✅/⏭️/❌` status markers are retained inside this summary.
+
+### Component 4 — Step 3: emit the spec (schema v2)
+
+`harness-profile.yaml` gains per-concern rationale. `meta.spec_version` becomes
+`2`. Required-when-`captured` fields now include `why` and `findings`;
+`alternatives_considered` is recommended. Example:
+
+```yaml
+meta:    { project: acme-api, generated_by: ymir, generated_at: 2026-06-18, spec_version: 2 }
+project: { language: typescript, runtime: bun, layer: backend, host: github }
+concerns:
+  lint:
+    status: captured
+    tool: biome
+    strict: true
+    style: { indent: tab, quotes: single }
+    why: "catch real bugs + kill mixed quote styles without config overhead"
+    findings: "missing — no linter config; src/ mixes single+double quotes"
+    alternatives_considered: [eslint+prettier]
+```
+
+`harness-playbook.md` per-concern sections gain a `**Why / Findings:**` block
+directly under the heading, filled from the profile via the existing `{{...}}`
+placeholder mechanism:
+
+```markdown
+## lint → linter config
+
+- **Why / Findings:** {{LINT_WHY}} — repo scan: {{LINT_FINDINGS}}. Considered: {{LINT_ALTERNATIVES}}.
+- **Target:** ...
+- **Inputs:** ...
+- **Steps:** ...
+- **Verify:** ...
+```
+
+`ymir apply` reads a section's `**Target:**` and `**Verify:**` lines and executes
+its `**Steps:**`. The new `**Why / Findings:**` bullet is none of those, so apply
+treats it as inert prose — the block is **non-breaking**.
+
+### Component 5 — Step 4: spec-review gate (NEW)
+
+After emitting, before offering `apply`, ymir tells the user the spec files are
+written and asks them to review:
+
+> "Spec written to `.ymir/harness-profile.yaml` and `.ymir/harness-playbook.md`.
+> Please review them and tell me if you want any changes before I generate the
+> harness."
+
+Wait for the response. On a change request, revisit the relevant concern, re-emit,
+and return to this gate. Only on approval proceed to Step 5 (offer apply). Step 5
+and the entire `apply`/`revert` flow are unchanged.
+
+## Data flow
+
+- **`ymir init`:** Step 0 scans → gap report → Step 1 sweeps the 5 concerns,
+  writing `decision`+`why`+`findings`+`alternatives` per concern into
+  `harness-profile.yaml` → Step 2 required-field check + consistency pass +
+  reflection gate → Step 3 assembles `harness-playbook.md` from the per-concern
+  templates → Step 4 spec-review gate → Step 5 offers `apply`.
+- **Narrow action (`ymir add lint`):** Step 0 scans only what's needed → confirm
+  item 0 if unknown → run the engine for `lint` only → consistency pass touching
+  `lint`'s couplings → reflection gate for `lint` → update the `lint:` block and
+  the `## lint` playbook section → offer `ymir apply lint`.
+- **Resume (existing `.ymir/`):** read the profile; treat any concern lacking
+  `why`/`findings` as needing depth on resume; ask only what's missing or
+  requested. Idempotent and resumable.
+- **Wiki-only intent (`ymir add context`/`add wiki`):** unchanged — executes the
+  wiki playbook template directly against the project.
+
+## Error handling
+
+- **"I don't know yet" for a decision** → concern stays `status: pending`; the
+  audit blocks emission until resolved or explicitly `skipped`.
+- **Greenfield repo / no signals** → all concerns `missing`; the engine asks cold
+  using the fallback phrasing; `findings` records `"missing — greenfield"`.
+- **Cross-concern conflict** → surfaced at Step 2(b); ymir loops back to re-ask the
+  implicated concern rather than emitting a spec with a silent contradiction.
+- **v1 profile from a prior run** → loads fine; ymir treats absent
+  `why`/`findings` as gaps to fill on resume and writes `spec_version: 2` on the
+  next emit. No destructive migration.
+- **User skips a concern** → `status: skipped` + reason; shown as `⏭️` in the
+  reflection summary; omitted from the playbook.
+
+## Testing
+
+ymir's skill behaviour is prose, so verification is lightweight and explicit:
+
+1. **Schema self-check** at the end of Step 3: validate `harness-profile.yaml`
+   against the v2 contract — including `why`/`findings` present for every
+   `captured` concern. Inline check; no new tooling (honours YAGNI).
+2. **Dry-run scenarios** (run manually during implementation, documented in the
+   plan):
+   - Existing repo with `eslint` already present → ymir detects it, Move 2
+     recommends keep/tune, `findings: present-weak`, `why` captured.
+   - Greenfield empty repo → fallback path, asks cold, `findings: missing`.
+   - Seeded cross-concern conflict (a rule needing a plugin biome lacks) → the
+     consistency pass flags it and loops back.
+3. **Backward-compat check:** a v1 profile loads, resumes, and upgrades to v2 on
+   next emit without data loss.
+4. **Apply non-regression:** `ymir apply` against a v2 spec still parses
+   `Target`/`Verify` correctly and ignores the `Why / Findings` block.
+
+## Boundaries (unchanged, and stronger)
+
+- Operate on the current project only (`cwd`).
+- **Spec only**, except the wiki-only intent (`ymir add context`/`add wiki`),
+  which executes the wiki scaffold directly — unchanged.
+- The interview is the source of truth; prefer asking over assuming — but now
+  *ground* the asking in what the codebase actually shows.
+- The five concerns are fixed; ymir deepens each, it does not drop or invent
+  concerns.
+
+## Open items pinned to build time
+
+- Exact detection heuristics per language/tool for Step 0 (finalize in the plan;
+  start with the common stacks already named in `templates/playbook/lint.md`).
+- Whether `findings` is a single prose string or a small structured object
+  (`{state, detail}`) — default to a prose string for YAGNI; revisit if the
+  consistency pass needs structured access.
+- The precise enumerated entries of the cross-concern consistency checklist
+  (finalize in the plan; the four couplings above are the seed set).

--- a/plugins/ymir/.claude-plugin/plugin.json
+++ b/plugins/ymir/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ymir",
   "version": "0.4.0",
-  "description": "Interviews the user about THIS project across a harness checklist (rules, lint, CI lint, wiki/context, CLAUDE.md), re-audits, and emits a spec under .ymir/. 'ymir apply' then generates the harness from the spec (with backups + 'ymir revert'). Never writes application code.",
+  "description": "Explores THIS project's codebase first, then runs a deep Socratic interview across a harness checklist (rules → .claude/rules/, lint, CI lint, wiki/context, CLAUDE.md), captures the rationale, re-audits for consistency, and emits a spec under .ymir/. 'ymir apply' then generates the harness from the spec (with backups + 'ymir revert'). Never writes application code.",
   "author": {
     "name": "articalam",
     "email": "lamhiep16@gmail.com"

--- a/plugins/ymir/SKILL.md
+++ b/plugins/ymir/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ymir
-description: Ymir interviews the user about THIS project (the current working directory) across a harness checklist, re-audits for completeness, and emits a SPEC under .ymir/ (the interview step writes only the spec). The spec covers rules, lint, CI lint, wiki/context, and CLAUDE.md/AGENT.md; 'ymir apply' then generates the harness from the spec (with backups + 'ymir revert'). Use whenever the user asks Ymir to do something to the project, e.g. "ymir init for this project", "ymir add lint", "ymir add rules", "ymir set up CI", "ymir apply", "ymir revert", "scaffold the harness", "bootstrap this repo".
+description: Ymir explores THIS project's codebase (the current working directory), then runs a deep Socratic interview across a harness checklist, re-audits for completeness + consistency, and emits a SPEC under .ymir/ (the interview step writes only the spec). The spec covers rules, lint, CI lint, wiki/context, and CLAUDE.md/AGENT.md; 'ymir apply' then generates the harness from the spec (with backups + 'ymir revert'). Use whenever the user asks Ymir to do something to the project, e.g. "ymir init for this project", "ymir add lint", "ymir add rules", "ymir set up CI", "ymir apply", "ymir revert", "scaffold the harness", "bootstrap this repo".
 argument-hint: "init | add lint | add rules | add ci | add context | add claude.md | apply [concern] | revert — what to do for this project"
 ---
 

--- a/plugins/ymir/SKILL.md
+++ b/plugins/ymir/SKILL.md
@@ -188,13 +188,14 @@ first.
 
 **1 — Load + preview.** Read the profile and the playbook. For each in-scope
 concern, read its `**Target:**` line from the playbook section to learn the
-artifact (a literal path like `docs/rules.md`, or a tool/provider-derived one
-such as the linter config for `concerns.lint.tool` or a workflow under
+artifact (a literal path, a directory like `.claude/rules/`, or a tool/provider-derived
+one such as the linter config for `concerns.lint.tool` or a workflow under
 `.github/workflows/`). Test whether that artifact already exists and print a plan
 table:
 
 | Concern | Target | State | Planned action |
 |---|---|---|---|
+| rules | `.claude/rules/` | missing | create |
 | lint | `eslint.config.mjs` | exists | ask keep/merge/overwrite |
 | wiki | `wiki/` | missing | create |
 
@@ -214,6 +215,10 @@ writing anything.
     changes into the existing file, guided by the playbook Steps.
   - *overwrite* → `cp "<file>" "<file>.backup.$run_id"`, then write the freshly
     generated artifact.
+- **Directory target (e.g. `.claude/rules/`)** → treat each file in it as its own
+  artifact: test existence, ask keep/merge/overwrite, and back up **per file**
+  (`cp "<file>" "<file>.backup.$run_id"`) so `ymir revert` restores them
+  individually.
 - **Rule:** back up **before** any overwrite or merge; never back up a file you
   are creating fresh.
 

--- a/plugins/ymir/SKILL.md
+++ b/plugins/ymir/SKILL.md
@@ -34,7 +34,7 @@ to the checklist of harness concerns above. Examples:
 
 | User says | Intent |
 |---|---|
-| `ymir init for this project` | sweep the whole checklist, audit, emit the spec |
+| `ymir init for this project` | understand the codebase, sweep the checklist, audit, emit the spec |
 | `ymir add lint for this project` | interview + audit only the `lint` concern; update the spec |
 | `ymir add rules` | interview + audit only `rules`; update the spec |
 | `ymir set up CI` | interview + audit only `ci`; update the spec |
@@ -84,65 +84,97 @@ plus the five concerns:
 | 4 | wiki / context | enabled?, collection name |
 | 5 | CLAUDE.md / AGENT.md | steering points (derived from 1–4) |
 
-## Step 1 — Checklist-driven interview (socratic)
+## Step 0 — Understand the project (codebase-first)
 
-The user does not hand-write code, so Ymir cannot infer the stack from files.
-Ask **one decision at a time** (`AskUserQuestion`), multiple-choice when possible.
-Walk the checklist: item 0 first, then the in-scope concerns.
+Before asking anything, scan the repo and build a **gap report**. Detect the
+foundation (language, runtime, layer, host) from manifests (`package.json`,
+`go.mod`, `pyproject.toml`, …), lockfiles, and the `.git` remote; and per concern
+detect current state + a verdict — `present-strong`, `present-weak`, or `missing`:
 
-- For `ymir init`, sweep the whole checklist.
-- For a narrow action (e.g. `add lint`), ask only item 0 (if not already in the
-  profile) plus that one concern.
+- `rules`: existing `.claude/rules/*.md`, conventions docs, `.editorconfig`, a
+  `CLAUDE.md`/`AGENT.md` rules section.
+- `lint`: a linter config present? which tool? strict?
+- `ci`: workflows present? what do they run?
+- `wiki`: a docs/context/wiki dir already used for project knowledge?
+- `claude_md`: `CLAUDE.md`/`AGENT.md` present? what does it steer?
+
+Print a one-line-per-concern findings summary so the interview is visibly
+grounded. **Greenfield fallback:** if there are no usable signals, mark every
+concern `missing` and proceed to ask cold.
+
+## Step 1 — Per-concern Socratic interview
+
+Walk item 0 (techstack — mostly **confirm** what Step 0 detected) then each
+in-scope concern. For each concern run the 4-move engine — **probe why → recommend
+(2-3 trade-offs, recommendation first) → adaptive follow-up only when needed →
+confirm** — asking **one question per `AskUserQuestion` message**. The full engine,
+the per-concern probe bank, the rules scope-probing, and the greenfield phrasing
+live in `${CLAUDE_PLUGIN_ROOT}/references/socratic-interview.md` — read it before
+interviewing.
+
+- For `ymir init`, sweep the whole checklist; for a narrow action (e.g. `add
+  lint`), run item 0 (if unknown) plus that one concern.
 - The user may skip a concern → record `status: skipped` with a `reason`.
-- Write each answer into `.ymir/harness-profile.yaml` as you go. Field shape and
-  required-fields-per-status:
+- Write each answer into `.ymir/harness-profile.yaml` as you go, including
+  `why`, `findings`, and `alternatives_considered`. Field shape:
   `${CLAUDE_PLUGIN_ROOT}/templates/harness-profile.schema.md`.
 
-## Step 2 — Re-audit (gate)
+## Step 2 — Consistency + re-audit (gate)
 
-Before emitting, re-check every in-scope concern against the schema's required
-fields (e.g. "have we clarified the techstack? the rules to obey/avoid? the lint
-tool?"):
+Before emitting:
 
-- Any required field missing → loop back and ask exactly that question; keep the
-  concern `status: pending` until resolved.
-- When all in-scope concerns are `captured` or `skipped`, print a coverage table
-  (`✅ captured` / `⏭️ skipped` / `❌ pending`) and ask the user to confirm.
+1. **Required-field check** — every in-scope concern has its decision fields plus
+   `why` and `findings`. Anything missing → keep the concern `pending` and loop
+   back to ask exactly that.
+2. **Cross-concern consistency pass** — run the bounded checklist in
+   `references/socratic-interview.md` ("Cross-concern consistency checklist"). On a
+   conflict, surface it plainly and **go back** to re-ask the implicated concern.
+3. **Reflection gate** — print, per concern, `decision + one-line why` (with
+   `✅ captured` / `⏭️ skipped` / `❌ pending` markers) and ask: *"Does this reflect
+   your intent? Want to revisit any concern before I write the spec?"*
 
 **Do not proceed to Step 3 while any in-scope concern is `pending`, or before the
-user confirms the coverage table.**
+user confirms the reflection summary.**
 
 ## Step 3 — Emit the spec
 
 Assemble the playbook from the bundled per-concern templates — do not free-form it:
 
-1. Ensure `.ymir/harness-profile.yaml` reflects the final audited decisions.
+1. Ensure `.ymir/harness-profile.yaml` reflects the final audited decisions
+   (`spec_version: 2`).
 2. Write `.ymir/harness-playbook.md`: start from
    `${CLAUDE_PLUGIN_ROOT}/templates/playbook/header.md` (fill `{{PROJECT}}` and
-   `{{DATE}}`), then append one section per `captured` concern, copied from
-   `${CLAUDE_PLUGIN_ROOT}/templates/playbook/<concern>.md`, filling any `{{...}}`
-   placeholders from the profile. Omit `skipped` concerns.
-3. Tell the user the spec is ready under `.ymir/`, and that a normal Claude Code
-   session can now follow `harness-playbook.md` to generate the harness.
+   `{{DATE}}`), then append one section per `captured` concern from
+   `${CLAUDE_PLUGIN_ROOT}/templates/playbook/<concern>.md`, filling every `{{...}}`
+   placeholder (including the `Why / Findings` block) from the profile. Omit
+   `skipped` concerns.
+3. Tell the user the spec is ready under `.ymir/`.
 
-(Spec-generation step only — never write the harness files here; only the two spec files above. `ymir apply` is the separate step that generates them.)
+(Spec-generation only — never write harness files here; `ymir apply` does that.)
 
-## Step 4 — Offer to apply (the full flow is init → apply)
+## Step 4 — Spec-review gate
 
-Emitting the spec is **not** the finish line — the user almost always wants the
-harness generated next. Do not stop and treat `init` as done. After the spec is
-written, **ask** (via `AskUserQuestion`) whether to generate it now:
+After emitting, before offering apply, ask the user to review the written files:
 
-> "Spec written to `.ymir/`. Generate the harness now with `ymir apply`?"
+> "Spec written to `.ymir/harness-profile.yaml` and `.ymir/harness-playbook.md`.
+> Please review them and tell me if you want any changes before I generate the
+> harness."
 
-- **Yes** → proceed directly into the "Applying the spec" flow below, in this same
-  session (preview → confirm → generate → verify). No need to re-run `ymir apply`
-  as a separate command.
+Wait. On a change request, revisit the relevant concern, re-emit, and return to
+this gate. Only on approval proceed to Step 5.
+
+## Step 5 — Offer to apply (the full flow is init → apply)
+
+After the user approves the spec, **ask** (via `AskUserQuestion`) whether to
+generate it now:
+
+> "Generate the harness now with `ymir apply`?"
+
+- **Yes** → proceed into the "Applying the spec" flow below, in this same session.
 - **No** → tell the user they can run `ymir apply` whenever they're ready; stop here.
 
 For a narrow intent (e.g. `ymir add lint`), offer `ymir apply lint` — apply just
-that one concern — instead of the full sweep. Never auto-run apply without a yes;
-apply writes files.
+that one concern. Never auto-run apply without a yes; apply writes files.
 
 ## Applying the spec — `ymir apply` (writes the harness)
 
@@ -227,4 +259,7 @@ manually or with `git clean` for a full undo.
   `ymir revert` (restores those backups). The wiki-only shortcut
   (`ymir add context` / `ymir add wiki`) also executes directly; `ymir apply wiki`
   reaches the same result through the general apply path.
-- Prefer asking over assuming; the interview is the source of truth.
+- Prefer asking over assuming — but ground the asking in what the codebase
+  actually shows (Step 0). The interview is the source of truth.
+- The `rules` concern emits native `.claude/rules/*.md` (path-scoped), not a
+  `docs/rules.md`; `CLAUDE.md` does not point at them (auto-discovered).

--- a/plugins/ymir/references/socratic-interview.md
+++ b/plugins/ymir/references/socratic-interview.md
@@ -1,0 +1,104 @@
+# Ymir Socratic Interview Engine
+
+This drives **Step 1** of `SKILL.md`. It turns the harness interview from a
+form-fill into a grounded dialogue. Read it before interviewing.
+
+## Cardinal rule — one question per message
+
+Every question is its own `AskUserQuestion` call. Ask one thing, then **stop and
+yield the floor**. Never batch questions "to be efficient" — batching freezes the
+conversation and you lose the ability to let an answer shape the next question.
+
+## Inputs from Step 0
+
+Before Step 1 you hold a **gap report**: for each concern a verdict of
+`present-strong`, `present-weak`, or `missing`, plus what was detected. Every
+question below is grounded in that finding — never ask something the scan already
+answered.
+
+## The per-concern loop (4 moves)
+
+Run this for each in-scope concern, in checklist order:
+
+1. **Probe the *why* (open, grounded).** Ask the purpose/pain behind the concern,
+   citing the finding. Not "which linter?" but "I see no linter and mixed quote
+   styles in `src/` — are you mainly after catching bugs, enforcing style, or
+   both?"
+2. **Recommend with trade-offs, recommendation first.** Offer 2-3 grounded
+   options, lead with your pick and why, invite challenge: "For TS/bun I'd pick
+   biome — one fast tool, near-zero config; trade-off vs eslint is fewer plugins.
+   Sound?"
+3. **Adaptive follow-up — only when needed.** Ask a follow-up *only* if the answer
+   reveals a gap, surprise, or contradiction. Otherwise go straight to confirm.
+   This is the friction ceiling that keeps it a dialogue, not an interrogation.
+4. **Confirm + record.** Write `decision`, `why`, `findings`,
+   `alternatives_considered` into `.ymir/harness-profile.yaml`, then advance.
+
+### Grounding by verdict
+
+- `present-strong` → confirm or tune what exists ("keep eslint as-is?").
+- `present-weak` → name the weakness and propose strengthening.
+- `missing` → propose adding — but apply **YAGNI**: if the user has no real need,
+  record `status: skipped` with a reason instead of forcing it.
+
+## Per-concern probe bank
+
+### project / techstack (item 0)
+Mostly **confirm** what Step 0 detected: "Detected TypeScript on bun, backend,
+GitHub — right?" Only ask cold if detection was empty.
+
+### rules → `.claude/rules/*.md` (special: scope probing)
+Rules become native Claude Code path-scoped rule files. After the *why*:
+- Elicit the conventions to **obey** and patterns to **avoid**.
+- For each rule (group), ask its **scope**: project-wide (always-on, no `paths`)
+  or scoped to files — "Does 'explicit return types' apply to all TS, or just
+  `src/api/**`?" Path-scoped rules load only when Claude reads a matching file.
+- Record one `files[]` entry per group: `{name, paths?, obey, avoid}`.
+
+### lint → linter config
+Why (bugs / style / both) → recommend a tool for the stack
+(biome / eslint / ruff / golangci-lint) with the trade-off → strictness →
+record `tool`, `strict`, `style`.
+
+### ci → CI workflow
+Why (gate PRs / catch regressions) → recommend the provider from `project.host`
+(github → github-actions) → what it runs (`runs: [lint]`) → record.
+
+### wiki / context
+Why (shared project knowledge for Claude) → enabled? → collection name →
+record `enabled`, `collection`.
+
+### claude_md → CLAUDE.md / AGENT.md
+Why (what should steer Claude here) → recommend steer points derived from
+concerns 2-4 (`lint-before-commit`, `point-to-wiki`). **Do NOT** add a
+`point-to-rules` steer — `.claude/rules/` auto-loads. Record `steer[]`.
+
+## Greenfield fallback
+
+If Step 0 found no signals (empty repo), there is no finding to cite. Ask the
+purpose directly, recommend sensible defaults for the declared stack, and record
+`findings: "missing — greenfield"`. This is the old onboarding behaviour, now a
+special case rather than the default.
+
+## Cross-concern consistency checklist (Step 2b)
+
+After the sweep, check these enumerated couplings. On a conflict, surface it
+plainly and **go back** to re-ask the implicated concern:
+
+- `lint.tool` ↔ `rules`: does a rule need enforcement the lint tool can't give? A
+  purely architectural rule is fine as a `.claude/rules/` file — but flag it if
+  the user expected lint to enforce it.
+- `rules` `paths` ↔ project layout: does each glob match real paths from Step 0?
+  Flag a glob that matches nothing (likely a typo or a dead directory).
+- `ci.provider` ↔ `project.host`: provider matches the host?
+- `lint.strict` ↔ `project.layer`/`runtime`: strictness sensible for the stack?
+- `claude_md.steer` ↔ concerns 2-4: steers toward the wiki/lint actually set up,
+  and does **not** redundantly point at `.claude/rules/`.
+
+## Anti-patterns (do not do these)
+
+- ❌ Asking "which tool?" with no *why* first — the bare field-question is the
+  shallow failure this engine exists to remove.
+- ❌ Batching multiple questions into one message.
+- ❌ Accepting the first answer without grounding it in the Step 0 finding.
+- ❌ Sweeping a concern the user has no need for instead of skipping it (YAGNI).

--- a/plugins/ymir/templates/harness-profile.schema.md
+++ b/plugins/ymir/templates/harness-profile.schema.md
@@ -11,7 +11,7 @@ spec (the LLM-facing half is `.ymir/harness-playbook.md`).
 | `meta.project` | yes | base name of the project directory |
 | `meta.generated_by` | yes | always `ymir` |
 | `meta.generated_at` | yes | ISO date (YYYY-MM-DD) |
-| `meta.spec_version` | yes | integer; `1` for this schema |
+| `meta.spec_version` | yes | integer; `2` for this schema |
 | `project.language` | yes | e.g. `typescript`, `go` |
 | `project.layer` | yes | `frontend` \| `backend` \| `both` |
 | `project.runtime` | recommended | e.g. `bun`, `node`, or omit if none |
@@ -27,23 +27,63 @@ spec (the LLM-facing half is `.ymir/harness-playbook.md`).
 
 ## Required fields per concern (only when `status: captured`)
 
-| Concern | Required when captured |
+Every captured concern additionally requires `why` (string — the pain/goal the
+user expressed) and `findings` (string — what the Step 0 codebase scan saw + a
+verdict of `present-strong` / `present-weak` / `missing`). `alternatives_considered`
+(list) is recommended.
+
+| Concern | Required when captured (besides `why` + `findings`) |
 |---|---|
-| `rules` | at least one of `obey[]` / `avoid[]` (or both empty with a `note: "no special rules"`) |
+| `rules` | at least one `files[]` entry; each entry needs a `name` and at least one of `obey[]` / `avoid[]` |
 | `lint` | `tool` |
 | `ci` | `provider`, `runs[]` |
 | `wiki` | `enabled`; and if `enabled: true`, then `collection` |
 | `claude_md` | `steer[]` |
 
+## `rules.files[]` — one native `.claude/rules/` file per entry
+
+Each entry maps to `.claude/rules/<name>.md`:
+
+| Key | Required | Notes |
+|---|---|---|
+| `name` | yes | kebab-case; becomes the filename (`<name>.md`) |
+| `paths` | no | YAML list of globs (e.g. `["src/**/*.{ts,tsx}"]`). Omit for an always-on rule (loads at launch like `CLAUDE.md`). |
+| `obey` | — | conventions to follow (≥1 of `obey`/`avoid` required) |
+| `avoid` | — | patterns to ban (rendered as a "NEVER" list) |
+
+**v1 → v2 migration:** a v1 profile's flat `rules.obey`/`rules.avoid` upgrades to a
+single always-on `files[]` entry named `project-conventions` (no `paths`). Absent
+`why`/`findings` are treated as gaps to fill on resume; the next emit writes
+`spec_version: 2`.
+
 ## Example
 
 ```yaml
-meta:    { project: acme-api, generated_by: ymir, generated_at: 2026-06-17, spec_version: 1 }
+meta:    { project: acme-api, generated_by: ymir, generated_at: 2026-06-18, spec_version: 2 }
 project: { language: typescript, runtime: bun, layer: backend, host: github }
 concerns:
-  rules:     { status: captured, obey: [functional-core-imperative-shell, explicit-return-types], avoid: [any, default-exports, throw-as-control-flow] }
-  lint:      { status: captured, tool: biome, strict: true, style: { indent: tab, quotes: single } }
-  ci:        { status: captured, provider: github-actions, runs: [lint] }
-  wiki:      { status: captured, enabled: true, collection: acme-api-wiki }
-  claude_md: { status: captured, steer: [point-to-rules, point-to-wiki, lint-before-commit] }
+  rules:
+    status: captured
+    files:
+      - name: typescript-conventions      # → .claude/rules/typescript-conventions.md
+        paths: ["src/**/*.{ts,tsx}"]       # omit `paths` for an always-on rule
+        obey: [functional-core-imperative-shell, explicit-return-types]
+        avoid: [any, default-exports]
+      - name: testing
+        paths: ["**/*.test.ts"]
+        obey: [arrange-act-assert]
+    why: "encode the conventions Claude keeps violating, scoped so they load only when relevant"
+    findings: "present-weak — conventions implied in code but undocumented; no .claude/rules/"
+    alternatives_considered: [single-CLAUDE.md-section, docs/rules.md]
+  lint:
+    status: captured
+    tool: biome
+    strict: true
+    style: { indent: tab, quotes: single }
+    why: "catch real bugs + kill mixed quote styles without config overhead"
+    findings: "missing — no linter config; src/ mixes single+double quotes"
+    alternatives_considered: [eslint+prettier]
+  ci:        { status: captured, provider: github-actions, runs: [lint], why: "block PRs that fail lint", findings: "missing — no workflows" }
+  wiki:      { status: captured, enabled: true, collection: acme-api-wiki, why: "shared project knowledge for Claude", findings: "missing" }
+  claude_md: { status: captured, steer: [point-to-wiki, lint-before-commit], why: "steer Claude to wiki + lint gate", findings: "present-weak — thin CLAUDE.md" }
 ```

--- a/plugins/ymir/templates/playbook/ci.md
+++ b/plugins/ymir/templates/playbook/ci.md
@@ -1,5 +1,6 @@
 ## CI lint → CI workflow
 
+- **Why / Findings:** {{CI_WHY}} — repo scan: {{CI_FINDINGS}}. Considered: {{CI_ALTERNATIVES}}.
 - **Target:** the CI workflow for `concerns.ci.provider` — use `concerns.ci.workflow` if the profile sets it, else the provider's conventional file (`.github/workflows/` for GitHub Actions, `.gitlab-ci.yml` for GitLab CI, `.circleci/config.yml` for CircleCI)
 - **Inputs:** `project.host`, `project.runtime`, `concerns.ci.provider`,
   `concerns.ci.runs[]`

--- a/plugins/ymir/templates/playbook/claude_md.md
+++ b/plugins/ymir/templates/playbook/claude_md.md
@@ -1,10 +1,13 @@
 ## CLAUDE.md / AGENT.md → steering file
 
+- **Why / Findings:** {{CLAUDE_MD_WHY}} — repo scan: {{CLAUDE_MD_FINDINGS}}. Considered: {{CLAUDE_MD_ALTERNATIVES}}.
 - **Target:** `CLAUDE.md` (or `AGENT.md`) at the project root
 - **Inputs:** `concerns.claude_md.steer[]`, plus the other captured concerns
 - **Steps:**
   1. Create or extend `CLAUDE.md` at the project root.
-  2. For each `steer[]` point, add a short directive — e.g. `point-to-rules`
-     links `docs/rules.md`; `point-to-wiki` links `wiki/SCHEMA.md`;
-     `lint-before-commit` tells Claude to run the lint command before commits.
-- **Verify:** `CLAUDE.md` exists and references every captured concern's artifact.
+  2. For each `steer[]` point, add a short directive — e.g. `point-to-wiki`
+     links `wiki/SCHEMA.md`; `lint-before-commit` tells Claude to run the lint
+     command before commits. Do NOT add a pointer to `.claude/rules/` — Claude
+     Code auto-discovers those; a `point-to-rules` steer is redundant.
+- **Verify:** `CLAUDE.md` exists and references the captured concerns it should
+  steer toward (wiki, lint), without pointing at `.claude/rules/`.

--- a/plugins/ymir/templates/playbook/header.md
+++ b/plugins/ymir/templates/playbook/header.md
@@ -7,3 +7,6 @@
 > **How to use:** read `.ymir/harness-profile.yaml` for decisions, then follow
 > the per-concern sections below. Each section lists the profile keys it
 > consumes (Inputs), the generation Steps, and how to Verify the result.
+>
+> Each section opens with a **Why / Findings** line recording the rationale and
+> what the codebase scan saw — context for the engineer/LLM; not an action.

--- a/plugins/ymir/templates/playbook/lint.md
+++ b/plugins/ymir/templates/playbook/lint.md
@@ -1,5 +1,6 @@
 ## lint → linter config
 
+- **Why / Findings:** {{LINT_WHY}} — repo scan: {{LINT_FINDINGS}}. Considered: {{LINT_ALTERNATIVES}}.
 - **Target:** the linter config for `concerns.lint.tool` — use `concerns.lint.config` if the profile sets it, else the tool's conventional file (`eslint` → `eslint.config.{mjs,js,cjs}` / `.eslintrc*`; `biome` → `biome.json` / `biome.jsonc`; `golangci-lint` → `.golangci.{yml,yaml}`; `ruff` → `ruff.toml` / `pyproject.toml`)
 - **Inputs:** `project.language`, `project.runtime`, `concerns.lint.tool`,
   `concerns.lint.strict`, `concerns.lint.style`

--- a/plugins/ymir/templates/playbook/rules.md
+++ b/plugins/ymir/templates/playbook/rules.md
@@ -1,11 +1,23 @@
-## rules → project rules doc
+## rules → `.claude/rules/` (native path-scoped rules)
 
-- **Target:** `docs/rules.md` (or the project's existing conventions doc)
-- **Inputs:** `concerns.rules.obey[]`, `concerns.rules.avoid[]`
+- **Why / Findings:** {{RULES_WHY}} — repo scan: {{RULES_FINDINGS}}. Considered: {{RULES_ALTERNATIVES}}.
+- **Target:** the `.claude/rules/` directory (one `<name>.md` file per `concerns.rules.files[]` entry)
+- **Inputs:** `concerns.rules.files[]` (each `{name, paths?, obey[], avoid[]}`)
 - **Steps:**
-  1. Create `docs/rules.md` (or the project's existing conventions doc).
-  2. Add a top **"NEVER"** list — one bullet per `avoid[]` item.
-  3. Add sections (Naming, Error handling, Module boundaries) phrased from the
+  1. For each entry in `concerns.rules.files[]`, create `.claude/rules/<name>.md`.
+  2. If the entry has `paths`, add YAML frontmatter listing each glob:
+
+     ```markdown
+     ---
+     paths:
+       - "<glob>"
+     ---
+     ```
+
+     If it has no `paths`, write no frontmatter (always-on rule).
+  3. Add a top **"NEVER"** list — one bullet per `avoid[]` item.
+  4. Add sections (Naming, Error handling, Module boundaries) phrased from the
      `obey[]` items.
-- **Verify:** `docs/rules.md` exists; every `avoid[]` item appears in the NEVER
-  list.
+- **Verify:** every `files[]` entry has a matching `.claude/rules/<name>.md`; each
+  scoped entry's frontmatter `paths` matches the profile; every `avoid[]` item
+  appears in its file's NEVER list.

--- a/plugins/ymir/templates/playbook/wiki.md
+++ b/plugins/ymir/templates/playbook/wiki.md
@@ -1,5 +1,6 @@
 ## wiki / context → LLM-maintained wiki
 
+- **Why / Findings:** {{WIKI_WHY}} — repo scan: {{WIKI_FINDINGS}}.
 - **Target:** the `wiki/` tree + `.claude/hooks/block-wiki-edits.mjs`
 - **Inputs:** `concerns.wiki.enabled` (run only when `true`), `concerns.wiki.collection`, `meta.project`
 


### PR DESCRIPTION
## What & why

Ymir's harness interview was labelled "socratic" but was structurally a schema-driven **form-fill**: it walked a fixed checklist asking each concern's required fields — never probing *why*, never recommending, never adapting — and `SKILL.md` even asserted it "cannot infer the stack from files." This PR transplants the **confirmed** behaviours of the Superpowers `brainstorming` interview engine into ymir, while keeping ymir spec-only and the fixed five concerns.

## The new flow (interview half only; `apply`/`revert` logic untouched)

- **Step 0 — codebase-first**: scan the repo, build a per-concern gap report (`present-strong` / `present-weak` / `missing`); greenfield repos fall back to asking cold.
- **Step 1 — per-concern engine**: probe *why* → recommend (2-3 trade-offs, recommendation first) → adaptive follow-up only when needed → confirm. One question per `AskUserQuestion` message.
- **Step 2 — consistency + re-audit**: required-field check + a bounded cross-concern consistency pass (go-back on conflict) + a reflection gate.
- **Step 4 — spec-review gate** before `apply`.
- Captures `why` / `findings` / `alternatives_considered` per concern in the emitted spec.

## Notable: `rules` → native `.claude/rules/`

The `rules` concern now emits native Claude Code path-scoped rule files (`.claude/rules/<name>.md` with optional `paths:` frontmatter globs), not a `docs/rules.md`. `CLAUDE.md` no longer points at them (auto-discovered). `ymir apply` handles the directory target with per-file backups so `ymir revert` stays clean.

## Files

- `templates/harness-profile.schema.md` → **v2** (`why`/`findings`/`alternatives_considered`; `rules.files[]`; v1→v2 migration).
- **New** `references/socratic-interview.md` — the engine (4-move loop, per-concern probe bank, consistency checklist, anti-patterns); `SKILL.md` stays lean and points to it.
- `SKILL.md` — Steps 0-5; `apply` directory-target handling.
- Playbook templates — `Why / Findings` block; `rules.md` → `.claude/rules/`; `claude_md.md` drops `point-to-rules`.
- `README.md` + `plugin.json` reframe.

Design + plan: `docs/superpowers/specs/2026-06-18-ymir-socratic-interview-design.md`, `docs/superpowers/plans/2026-06-18-ymir-socratic-interview.md`.

## Verification

- wiki-cli test suite: **90 pass / 0 fail** on the rebased tree.
- Structural cross-file sweeps: `spec_version: 2` consistent, `.claude/rules/` target wired, reference doc wired, no stray `docs/rules.md` target, no conflict markers.
- Documentation trace-through of 4 dry-run scenarios (existing/present-weak, greenfield, rules scope, cross-concern conflict). A live `/ymir init` smoke test is recommended as final acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
