### PR TITLE
fix(wiki-cli): make page identity collision-safe and prevent silent overwrites

### DIFF
--- a/plugins/ymir/wiki-cli/src/commands/help.ts
+++ b/plugins/ymir/wiki-cli/src/commands/help.ts
@@ -10,7 +10,9 @@ Commands:
                                       Create/update a synthesis note. Body from STDIN.
   index                               Rebuild index.md from all pages.
   log <op> <title>                    Append a dated entry to log.md.
-  validate                            Check frontmatter, [[links]], orphans. Exit !=0 on error.
+  validate                            Check frontmatter, [[links]], orphans, slug collisions,
+                                      filename/title mismatches, and nested pages.
+                                      Exit !=0 on error.
   fmt                                 Format all wiki markdown (remark).
   query <q> [--limit <n>] [--chunks] [--verbatim]
                                       Search this wiki via qmd (read side). Scoped to

--- a/plugins/ymir/wiki-cli/src/commands/ingest.ts
+++ b/plugins/ymir/wiki-cli/src/commands/ingest.ts
@@ -1,5 +1,6 @@
 import { existsSync, rmSync } from "node:fs";
 import { renderSourcePage } from "../pages.js";
+import { parseFrontmatter } from "../frontmatter.js";
 import { writePage, readPage } from "../store.js";
 import { sourcePath, wikiPaths } from "../paths.js";
 import { buildIndex } from "../index-build.js";
@@ -30,6 +31,14 @@ export async function runIngest(i: IngestInput): Promise<string> {
     sourceHash: i.sourceHash,
   });
   const path = sourcePath(i.root, i.title);
+  if (existsSync(path)) {
+    const existingTitle = (parseFrontmatter(readPage(path)).data as { title?: string }).title;
+    if (existingTitle !== i.title) {
+      throw new Error(
+        `ingest rejected: slug collision — "${path}" already holds "${existingTitle}", cannot overwrite with "${i.title}"`,
+      );
+    }
+  }
   const prev = existsSync(path) ? readPage(path) : null;
   writePage(path, page);
 

--- a/plugins/ymir/wiki-cli/src/commands/note.ts
+++ b/plugins/ymir/wiki-cli/src/commands/note.ts
@@ -18,9 +18,17 @@ export interface NoteInput {
 export async function runNote(i: NoteInput): Promise<string> {
   const path = notePath(i.root, i.name);
   const existed = existsSync(path);
-  const prevSourceCount = existed
-    ? ((parseFrontmatter(readPage(path)).data as { source_count?: number }).source_count ?? 0)
-    : 0;
+  let prevSourceCount = 0;
+  if (existed) {
+    const existing = parseFrontmatter(readPage(path));
+    const data = existing.data as { title?: string; source_count?: number };
+    if (data.title !== i.name) {
+      throw new Error(
+        `note rejected: slug collision — "${path}" already holds "${data.title}", cannot overwrite with "${i.name}"`,
+      );
+    }
+    prevSourceCount = data.source_count ?? 0;
+  }
 
   const page = await renderNotePage({
     name: i.name, type: i.type, date: i.today,

--- a/plugins/ymir/wiki-cli/src/templates/wiki/SCHEMA.md
+++ b/plugins/ymir/wiki-cli/src/templates/wiki/SCHEMA.md
@@ -25,7 +25,7 @@ Run `... help` for the full command reference. Key commands:
   Use `--raw <label>` (legacy) when ingesting from a non-tracked input.
 - `note --type entity|concept|topic --name <n>` (body on STDIN) — synthesis page.
 - `index` — rebuild the catalog.
-- `validate` — health check (frontmatter, `[[links]]`, orphans).
+- `validate` — health check (frontmatter, `[[links]]`, orphans, slug collisions, filename/title mismatches, nested pages).
 - `status` — show drift between source pages and their tracked files.
   Use `--json` for machine-readable output (exit 1 if stale/missing).
 - `reindex` — refresh the search index (creates the collection, or `qmd update`s it).

--- a/plugins/ymir/wiki-cli/src/validate.ts
+++ b/plugins/ymir/wiki-cli/src/validate.ts
@@ -1,4 +1,5 @@
-import { join } from "node:path";
+import { join, basename } from "node:path";
+import { existsSync, readdirSync } from "node:fs";
 import { parseFrontmatter } from "./frontmatter.js";
 import { listPages, readPage } from "./store.js";
 import { sourceFrontmatter, noteFrontmatter } from "./schema.js";
@@ -11,6 +12,27 @@ export interface ValidationResult {
 }
 
 interface Page { rel: string; title: string; body: string; links: string[]; }
+
+function nestedMarkdownPaths(dir: string, relPrefix: string): string[] {
+  if (!existsSync(dir)) return [];
+  const found: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    walkDir(join(dir, entry.name), `${relPrefix}/${entry.name}`, found);
+  }
+  return found;
+}
+
+function walkDir(dir: string, relPrefix: string, acc: string[]): void {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const rel = `${relPrefix}/${entry.name}`;
+    if (entry.isDirectory()) {
+      walkDir(join(dir, entry.name), rel, acc);
+    } else if (entry.name.endsWith(".md")) {
+      acc.push(rel);
+    }
+  }
+}
 
 function loadDir(root: string, sub: string, errors: string[]): Page[] {
   const out: Page[] = [];
@@ -32,9 +54,37 @@ function loadDir(root: string, sub: string, errors: string[]): Page[] {
 export function validateWiki(root: string): ValidationResult {
   const errors: string[] = [];
   const warnings: string[] = [];
+
+  for (const sub of ["sources", "notes"]) {
+    for (const rel of nestedMarkdownPaths(join(root, sub), sub)) {
+      errors.push(`${rel}: nested page not supported — move to ${sub}/ root or remove`);
+    }
+  }
+
   const sources = loadDir(root, "sources", errors);
   const notes = loadDir(root, "notes", errors);
   const all = [...sources, ...notes];
+
+  for (const p of all) {
+    const filename = basename(p.rel);
+    const expected = `${slugify(p.title)}.md`;
+    if (filename !== expected) {
+      errors.push(`${p.rel}: filename "${filename}" does not match title "${p.title}" (expected "${expected}") — rename the file or update the title`);
+    }
+  }
+
+  const slugMap = new Map<string, string[]>();
+  for (const p of all) {
+    const slug = slugify(p.title);
+    const existing = slugMap.get(slug) ?? [];
+    existing.push(p.rel);
+    slugMap.set(slug, existing);
+  }
+  for (const [slug, rels] of slugMap) {
+    if (rels.length > 1) {
+      errors.push(`slug collision "${slug}": ${rels.join(", ")} — rename pages to use distinct titles`);
+    }
+  }
 
   const slugs = new Set(all.map((p) => slugify(p.title)));
   const inbound = new Set<string>();

--- a/plugins/ymir/wiki-cli/test/ingest.test.ts
+++ b/plugins/ymir/wiki-cli/test/ingest.test.ts
@@ -44,4 +44,19 @@ describe("runIngest", () => {
 
     expect(readPage(join(root, "sources", "doc-a.md"))).toBe(original);
   });
+
+  it("rejects a title whose slug collides with an existing page of a different title", async () => {
+    await runIngest({
+      root, raw: "raw/a.pdf", title: "Hiệu trưởng",
+      body: "See [[Hiệu trưởng]].", today: "2026-06-17",
+    });
+    const original = readPage(join(root, "sources", "hi-u-tr-ng.md"));
+
+    await expect(runIngest({
+      root, raw: "raw/b.pdf", title: "Hiếu trường",
+      body: "See [[Hiệu trưởng]].", today: "2026-06-18",
+    })).rejects.toThrow(/collision/);
+
+    expect(readPage(join(root, "sources", "hi-u-tr-ng.md"))).toBe(original);
+  });
 });

--- a/plugins/ymir/wiki-cli/test/note.test.ts
+++ b/plugins/ymir/wiki-cli/test/note.test.ts
@@ -40,4 +40,19 @@ describe("runNote", () => {
     expect(page).toContain("source_count: 3");
     expect(page).toContain("Updated body.");
   });
+
+  it("rejects a note name whose slug collides with an existing note of a different name", async () => {
+    await runNote({
+      root, type: "concept", name: "Hiệu trưởng",
+      body: "Original note.", today: "2026-06-17",
+    });
+    const original = readPage(join(root, "notes", "hi-u-tr-ng.md"));
+
+    await expect(runNote({
+      root, type: "concept", name: "Hiếu trường",
+      body: "Colliding note.", today: "2026-06-18",
+    })).rejects.toThrow(/collision/);
+
+    expect(readPage(join(root, "notes", "hi-u-tr-ng.md"))).toBe(original);
+  });
 });

--- a/plugins/ymir/wiki-cli/test/validate.test.ts
+++ b/plugins/ymir/wiki-cli/test/validate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { writePage } from "../src/store.js";
@@ -10,6 +10,9 @@ beforeEach(() => { root = mkdtempSync(join(tmpdir(), "wiki-")); });
 
 const goodNote = (title: string, body = "") =>
   `---\ntitle: ${title}\ntype: concept\ndate: 2026-06-17\ntags: []\nsource_count: 0\n---\n# ${title}\n\n${body}\n`;
+
+const goodSource = (title: string, body = "") =>
+  `---\ntitle: ${title}\ntype: source\ndate: 2026-06-17\ntags: []\nsource: raw/a.pdf\ningested: 2026-06-17\n---\n# ${title}\n\n${body}\n`;
 
 describe("validateWiki", () => {
   it("passes a clean wiki", () => {
@@ -34,5 +37,28 @@ describe("validateWiki", () => {
     writePage(join(root, "notes", "a.md"), goodNote("A"));
     const r = validateWiki(root);
     expect(r.warnings.some((w) => w.includes("orphan") && w.includes("A"))).toBe(true);
+  });
+
+  it("flags slug collision between two Vietnamese titles that produce identical slugs", () => {
+    writePage(join(root, "sources", "hi-u-tr-ng.md"), goodSource("Hiệu trưởng"));
+    writePage(join(root, "notes", "hi-u-tr-ng.md"), goodNote("Hiếu trường"));
+    const r = validateWiki(root);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("slug collision"))).toBe(true);
+  });
+
+  it("flags a hand-renamed file whose filename no longer matches its title", () => {
+    writePage(join(root, "notes", "wrong-name.md"), goodNote("Right Name"));
+    const r = validateWiki(root);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("wrong-name.md") && e.includes("filename"))).toBe(true);
+  });
+
+  it("flags markdown files in unsupported nested subdirectories", () => {
+    mkdirSync(join(root, "notes", "subfolder"), { recursive: true });
+    writePage(join(root, "notes", "subfolder", "deep.md"), goodNote("Deep Page"));
+    const r = validateWiki(root);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("nested") && e.includes("subfolder"))).toBe(true);
   });
 });

--- a/wiki/SCHEMA.md
+++ b/wiki/SCHEMA.md
@@ -23,7 +23,7 @@ Run `... help` for the full command reference. Key commands:
 - `ingest --raw <raw/path> --title <t>` (body on STDIN) — summarize a source.
 - `note --type entity|concept|topic --name <n>` (body on STDIN) — synthesis page.
 - `index` — rebuild the catalog.
-- `validate` — health check (frontmatter, `[[links]]`, orphans).
+- `validate` — health check (frontmatter, `[[links]]`, orphans, slug collisions, filename/title mismatches, nested pages).
 - `query <q>` — search via qmd.
 
 ## Page conventions


### PR DESCRIPTION
## Summary

- **Guard `ingest` and `note` against slug collisions**: before writing, check if the target path already holds a different title; throw an explicit collision error immediately without touching the file
- **Extend `validate` with three new checks**: slug collisions across the whole wiki (two titles → same ASCII slug), filename/title mismatches (hand-renamed files), and markdown pages in unsupported nested subdirectories
- **Update CLI help and SCHEMA.md** to document the extended validate behaviour

Fixes #23

## Test plan

- [ ] `bun test test/validate.test.ts` — new tests for slug collision (Vietnamese titles), filename mismatch, nested pages detection
- [ ] `bun test test/ingest.test.ts` — new test: ingest with colliding Vietnamese title is rejected, original page preserved
- [ ] `bun test test/note.test.ts` — new test: note with colliding Vietnamese name is rejected, original note preserved
- [ ] All 146 existing tests continue to pass (`bun test --timeout 15000`)
- [ ] TypeScript type-check passes (`bun run typecheck`)