### PR TITLE
feat(wiki-cli): add declarative source coverage with reasoned exclusions

### DIFF
--- a/plugins/ymir/wiki-cli/bun.lock
+++ b/plugins/ymir/wiki-cli/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "commander": "^15.0.0",
         "js-yaml": "^4.2.0",
+        "minimatch": "^10.2.6",
         "remark": "^15.0.1",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.0",
@@ -38,6 +39,10 @@
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
@@ -152,6 +157,8 @@
     "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
+
+    "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 

--- a/plugins/ymir/wiki-cli/package.json
+++ b/plugins/ymir/wiki-cli/package.json
@@ -3,7 +3,9 @@
   "version": "0.2.0",
   "private": true,
   "type": "module",
-  "bin": { "wiki": "dist/cli.js" },
+  "bin": {
+    "wiki": "dist/cli.js"
+  },
   "scripts": {
     "build": "bun build ./src/cli.ts --outfile dist/cli.js --target node --format esm --banner \"#!/usr/bin/env node\" && chmod +x dist/cli.js",
     "test": "bun test",
@@ -16,6 +18,7 @@
   "dependencies": {
     "commander": "^15.0.0",
     "js-yaml": "^4.2.0",
+    "minimatch": "^10.2.6",
     "remark": "^15.0.1",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.0",

--- a/plugins/ymir/wiki-cli/src/cli.ts
+++ b/plugins/ymir/wiki-cli/src/cli.ts
@@ -9,6 +9,7 @@ import { buildIndex } from "./index-build.js";
 import { appendLog, type LogOp } from "./wikilog.js";
 import { validateWiki } from "./validate.js";
 import { runStatus } from "./commands/status.js";
+import { runCoverage } from "./commands/coverage.js";
 import { formatMarkdown } from "./format.js";
 import { writePage, readPage, listPages } from "./store.js";
 import { wikiPaths } from "./paths.js";
@@ -175,6 +176,16 @@ program
   .action((opts: { json: boolean }) => {
     const root = program.opts<{ root: string }>().root;
     const { text, exitCode } = runStatus({ root, json: opts.json });
+    process.stdout.write(text);
+    if (exitCode !== 0) process.exit(exitCode);
+  });
+
+program
+  .command("coverage")
+  .option("--json", "emit JSON output", false)
+  .action((opts: { json: boolean }) => {
+    const root = program.opts<{ root: string }>().root;
+    const { text, exitCode } = runCoverage({ root, json: opts.json });
     process.stdout.write(text);
     if (exitCode !== 0) process.exit(exitCode);
   });

--- a/plugins/ymir/wiki-cli/src/commands/coverage.ts
+++ b/plugins/ymir/wiki-cli/src/commands/coverage.ts
@@ -1,0 +1,62 @@
+import { resolve } from "node:path";
+import { wikiPaths } from "../paths.js";
+import {
+  loadCoverageConfig,
+  collectProjectFiles,
+  loadSourcePages,
+  checkCoverage,
+  type CoverageViolation,
+} from "../coverage.js";
+
+export interface CoverageInput {
+  root: string;
+  json: boolean;
+}
+
+export interface CoverageOutput {
+  text: string;
+  exitCode: number;
+}
+
+function formatViolation(v: CoverageViolation): string {
+  switch (v.kind) {
+    case "uncovered":
+      return `uncovered: ${v.file}\n  remedy: ${v.remedy}`;
+    case "stale-exclusion":
+      return `stale exclusion: "${v.pattern}"\n  remedy: ${v.remedy}`;
+    case "excluded-ingested":
+      return `excluded but ingested: ${v.file} (${v.pages?.join(", ")})\n  remedy: ${v.remedy}`;
+    case "out-of-scope":
+      return `out-of-scope source page: ${v.file} (${v.pages?.join(", ")})\n  remedy: ${v.remedy}`;
+    case "duplicate-source":
+      return `duplicate source: ${v.file} claimed by ${v.pages?.join(", ")}\n  remedy: ${v.remedy}`;
+  }
+}
+
+export function runCoverage(i: CoverageInput): CoverageOutput {
+  const paths = wikiPaths(i.root);
+  const projectRoot = resolve(i.root, "..");
+
+  const config = loadCoverageConfig(i.root);
+  if (!config) {
+    return {
+      text: `no tracked.yaml found in ${i.root} — create one to enable coverage checks\n`,
+      exitCode: 0,
+    };
+  }
+
+  const projectFiles = collectProjectFiles(projectRoot);
+  const sourcePages = loadSourcePages(paths.sourcesDir);
+  const report = checkCoverage(config, projectFiles, sourcePages);
+
+  if (i.json) {
+    return { text: JSON.stringify(report, null, 2) + "\n", exitCode: report.ok ? 0 : 1 };
+  }
+
+  if (report.ok) {
+    return { text: "coverage ok\n", exitCode: 0 };
+  }
+
+  const lines = report.violations.map(formatViolation);
+  return { text: lines.join("\n") + "\n", exitCode: 1 };
+}

--- a/plugins/ymir/wiki-cli/src/coverage.ts
+++ b/plugins/ymir/wiki-cli/src/coverage.ts
@@ -1,0 +1,172 @@
+import { join } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { load, JSON_SCHEMA } from "js-yaml";
+import { minimatch } from "minimatch";
+import { z } from "zod";
+import { parseFrontmatter } from "./frontmatter.js";
+import { listPages } from "./store.js";
+
+const ExclusionRuleSchema = z.object({
+  pattern: z.string().min(1),
+  reason: z.string().min(1),
+});
+
+const CoverageConfigSchema = z.object({
+  include: z.array(z.string().min(1)),
+  exclude: z.array(ExclusionRuleSchema).default([]),
+});
+
+export type CoverageConfig = z.infer<typeof CoverageConfigSchema>;
+export type ExclusionRule = z.infer<typeof ExclusionRuleSchema>;
+
+export type ViolationKind =
+  | "uncovered"
+  | "stale-exclusion"
+  | "excluded-ingested"
+  | "out-of-scope"
+  | "duplicate-source";
+
+export interface CoverageViolation {
+  kind: ViolationKind;
+  file?: string;
+  pattern?: string;
+  pages?: string[];
+  remedy: string;
+}
+
+export interface CoverageReport {
+  ok: boolean;
+  violations: CoverageViolation[];
+}
+
+export interface SourcePageRecord {
+  rel: string;
+  sourcePath?: string;
+}
+
+export function parseCoverageConfig(raw: string): CoverageConfig {
+  const parsed = load(raw, { schema: JSON_SCHEMA });
+  return CoverageConfigSchema.parse(parsed);
+}
+
+export function loadCoverageConfig(wikiRoot: string): CoverageConfig | null {
+  const configPath = join(wikiRoot, "tracked.yaml");
+  if (!existsSync(configPath)) return null;
+  return parseCoverageConfig(readFileSync(configPath, "utf8"));
+}
+
+function toForwardSlash(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+function matchesAny(file: string, patterns: string[]): boolean {
+  return patterns.some((p) => minimatch(file, p, { dot: true }));
+}
+
+export function collectProjectFiles(projectRoot: string): string[] {
+  try {
+    const out = execSync("git ls-files", { cwd: projectRoot, encoding: "utf8", stdio: ["pipe", "pipe", "ignore"] });
+    return out.trim().split("\n").filter(Boolean).map(toForwardSlash);
+  } catch {
+    return walkDir(projectRoot, projectRoot);
+  }
+}
+
+function walkDir(dir: string, root: string): string[] {
+  const result: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const abs = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      result.push(...walkDir(abs, root));
+    } else {
+      result.push(toForwardSlash(abs.slice(root.length + 1)));
+    }
+  }
+  return result;
+}
+
+export function loadSourcePages(sourcesDir: string): SourcePageRecord[] {
+  return listPages(sourcesDir).map((file) => {
+    const rel = `sources/${file}`;
+    const { data } = parseFrontmatter(readFileSync(join(sourcesDir, file), "utf8"));
+    const rawPath = (data as { source_path?: string }).source_path;
+    return { rel, sourcePath: rawPath ? toForwardSlash(rawPath) : undefined };
+  });
+}
+
+export function checkCoverage(
+  config: CoverageConfig,
+  projectFiles: string[],
+  sourcePages: SourcePageRecord[],
+): CoverageReport {
+  const violations: CoverageViolation[] = [];
+  const excludePatterns = config.exclude.map((e) => e.pattern);
+
+  const normalizedPages = sourcePages.map((p) => ({
+    ...p,
+    sourcePath: p.sourcePath ? toForwardSlash(p.sourcePath) : undefined,
+  }));
+
+  const ingestedMap = new Map<string, string[]>();
+  for (const page of normalizedPages) {
+    if (!page.sourcePath) continue;
+    const existing = ingestedMap.get(page.sourcePath) ?? [];
+    existing.push(page.rel);
+    ingestedMap.set(page.sourcePath, existing);
+  }
+
+  const inScopeFiles = projectFiles.filter(
+    (f) => matchesAny(f, config.include) && !matchesAny(f, excludePatterns),
+  );
+
+  for (const file of inScopeFiles) {
+    if (!ingestedMap.has(file)) {
+      violations.push({
+        kind: "uncovered",
+        file,
+        remedy: `run: wiki ingest --source ${file} --title "<title>"`,
+      });
+    }
+  }
+
+  for (const rule of config.exclude) {
+    const hasMatch = projectFiles.some((f) => minimatch(f, rule.pattern, { dot: true }));
+    if (!hasMatch) {
+      violations.push({
+        kind: "stale-exclusion",
+        pattern: rule.pattern,
+        remedy: `remove the exclusion "${rule.pattern}" from tracked.yaml (no files match it)`,
+      });
+    }
+  }
+
+  for (const [sourcePath, pages] of ingestedMap) {
+    if (matchesAny(sourcePath, excludePatterns)) {
+      violations.push({
+        kind: "excluded-ingested",
+        file: sourcePath,
+        pages,
+        remedy: `remove the source page or remove the exclusion covering "${sourcePath}" from tracked.yaml`,
+      });
+    } else if (!matchesAny(sourcePath, config.include)) {
+      violations.push({
+        kind: "out-of-scope",
+        file: sourcePath,
+        pages,
+        remedy: `add "${sourcePath}" to tracked.yaml includes or remove the source page`,
+      });
+    }
+
+    if (pages.length > 1) {
+      violations.push({
+        kind: "duplicate-source",
+        file: sourcePath,
+        pages,
+        remedy: `keep one source page for "${sourcePath}" and remove the duplicates: ${pages.join(", ")}`,
+      });
+    }
+  }
+
+  return { ok: violations.length === 0, violations };
+}

--- a/plugins/ymir/wiki-cli/src/templates/wiki/SCHEMA.md
+++ b/plugins/ymir/wiki-cli/src/templates/wiki/SCHEMA.md
@@ -28,6 +28,10 @@ Run `... help` for the full command reference. Key commands:
 - `validate` — health check (frontmatter, `[[links]]`, orphans, slug collisions, filename/title mismatches, nested pages).
 - `status` — show drift between source pages and their tracked files.
   Use `--json` for machine-readable output (exit 1 if stale/missing).
+- `coverage` — verify declarative source coverage defined in `wiki/tracked.yaml`.
+  Fails when an in-scope file has no source page, an exclusion is stale, a file is
+  excluded yet ingested, a source page is out of scope, or multiple pages claim the
+  same file. Use `--json` for machine-readable output (exit 1 on any violation).
 - `reindex` — refresh the search index (creates the collection, or `qmd update`s it).
 - `query <q> [--limit <n>] [--chunks] [--verbatim] [--full|--snippet] [--context <chars>]` — search this wiki via qmd.
 
@@ -45,6 +49,31 @@ Run `... help` for the full command reference. Key commands:
   optionally file the answer back as a `note`.
 - **Lint:** run `validate` → fix reported issues by issuing further CLI commands.
 - **Drift check:** run `status` → re-ingest stale pages with updated summaries.
+- **Coverage check:** run `coverage` → follow each violation's remedy to ingest missing files
+  or update `wiki/tracked.yaml`.
+
+## Source coverage (`wiki/tracked.yaml`)
+
+Create `wiki/tracked.yaml` to declare which project files the wiki must cover:
+
+```yaml
+include:
+  - "src/**/*.ts"
+  - "docs/**/*.md"
+exclude:
+  - pattern: "src/generated/**"
+    reason: "Auto-generated — not authored documentation"
+```
+
+- `include` — glob patterns relative to the project root. Every matching file that
+  is not excluded must have an ingested source page.
+- `exclude` — patterns with a mandatory `reason`. Each exclusion must match at least
+  one file (stale exclusions fail the check). A file that is excluded must not have
+  a source page.
+
+Run `wiki coverage` to verify. Each violation includes an actionable remedy.
+File discovery uses `git ls-files` so untracked scratch files in a worktree do not
+create false failures.
 
 ## Auto-Sync (drift detection)
 

--- a/plugins/ymir/wiki-cli/test/coverage-cmd.test.ts
+++ b/plugins/ymir/wiki-cli/test/coverage-cmd.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runCoverage } from "../src/commands/coverage.js";
+
+function initProject(): { projectRoot: string; wikiRoot: string } {
+  const projectRoot = mkdtempSync(join(tmpdir(), "coverage-cmd-"));
+  const wikiRoot = join(projectRoot, "wiki");
+  mkdirSync(join(wikiRoot, "sources"), { recursive: true });
+  mkdirSync(join(wikiRoot, "notes"), { recursive: true });
+  return { projectRoot, wikiRoot };
+}
+
+function writeTracked(wikiRoot: string, yaml: string): void {
+  writeFileSync(join(wikiRoot, "tracked.yaml"), yaml);
+}
+
+function writeSourcePage(wikiRoot: string, file: string, sourcePath?: string): void {
+  const fm: Record<string, unknown> = {
+    title: file.replace(/\.md$/, ""),
+    type: "source",
+    date: "2026-06-17",
+    tags: [],
+    source: "raw/stub",
+    ingested: "2026-06-17",
+  };
+  if (sourcePath) fm.source_path = sourcePath;
+  const lines = ["---"];
+  for (const [k, v] of Object.entries(fm)) {
+    if (Array.isArray(v)) lines.push(`${k}:\n${v.map((x) => `  - ${x}`).join("\n")}`);
+    else lines.push(`${k}: ${v}`);
+  }
+  lines.push("---", `# ${fm.title}`, "", "content");
+  writeFileSync(join(wikiRoot, "sources", file), lines.join("\n") + "\n");
+}
+
+let projectRoot: string;
+let wikiRoot: string;
+
+beforeEach(() => {
+  ({ projectRoot, wikiRoot } = initProject());
+});
+
+afterEach(() => {
+  rmSync(projectRoot, { recursive: true, force: true });
+});
+
+describe("runCoverage", () => {
+  it("exits 0 with guidance when no tracked.yaml present", () => {
+    const r = runCoverage({ root: wikiRoot, json: false });
+    expect(r.exitCode).toBe(0);
+    expect(r.text).toContain("tracked.yaml");
+  });
+
+  it("exits 0 when coverage is satisfied", () => {
+    mkdirSync(join(projectRoot, "src"), { recursive: true });
+    writeFileSync(join(projectRoot, "src", "auth.ts"), "content");
+    writeTracked(wikiRoot, 'include:\n  - "src/**/*.ts"\n');
+    writeSourcePage(wikiRoot, "auth.md", "src/auth.ts");
+
+    const r = runCoverage({ root: wikiRoot, json: false });
+    expect(r.exitCode).toBe(0);
+    expect(r.text).toContain("coverage ok");
+  });
+
+  it("exits 1 with uncovered violation when file missing a source page", () => {
+    mkdirSync(join(projectRoot, "src"), { recursive: true });
+    writeFileSync(join(projectRoot, "src", "user.ts"), "content");
+    writeTracked(wikiRoot, 'include:\n  - "src/**/*.ts"\n');
+
+    const r = runCoverage({ root: wikiRoot, json: false });
+    expect(r.exitCode).toBe(1);
+    expect(r.text).toContain("uncovered");
+    expect(r.text).toContain("src/user.ts");
+  });
+
+  it("emits JSON when --json flag is set", () => {
+    writeTracked(wikiRoot, 'include:\n  - "src/**/*.ts"\n');
+    const r = runCoverage({ root: wikiRoot, json: true });
+    const parsed = JSON.parse(r.text) as { ok: boolean; violations: unknown[] };
+    expect(typeof parsed.ok).toBe("boolean");
+    expect(Array.isArray(parsed.violations)).toBe(true);
+  });
+});

--- a/plugins/ymir/wiki-cli/test/coverage.test.ts
+++ b/plugins/ymir/wiki-cli/test/coverage.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from "bun:test";
+import {
+  checkCoverage,
+  parseCoverageConfig,
+  type CoverageConfig,
+  type SourcePageRecord,
+} from "../src/coverage.js";
+
+function cfg(include: string[], exclude: { pattern: string; reason: string }[] = []): CoverageConfig {
+  return { include, exclude };
+}
+
+function src(rel: string, sourcePath?: string): SourcePageRecord {
+  return { rel, sourcePath };
+}
+
+describe("parseCoverageConfig", () => {
+  it("parses include-only config", () => {
+    const c = parseCoverageConfig(`include:\n  - "src/**/*.ts"\n`);
+    expect(c.include).toEqual(["src/**/*.ts"]);
+    expect(c.exclude).toEqual([]);
+  });
+
+  it("parses config with exclusions", () => {
+    const yaml = [
+      "include:",
+      '  - "src/**/*.ts"',
+      "exclude:",
+      "  - pattern: src/generated/**",
+      "    reason: auto-generated",
+    ].join("\n");
+    const c = parseCoverageConfig(yaml);
+    expect(c.exclude[0]?.pattern).toBe("src/generated/**");
+    expect(c.exclude[0]?.reason).toBe("auto-generated");
+  });
+
+  it("rejects exclusion with empty reason", () => {
+    const yaml = ['include:\n  - "src/**"', 'exclude:\n  - pattern: "src/x"\n    reason: ""'].join("\n");
+    expect(() => parseCoverageConfig(yaml)).toThrow();
+  });
+});
+
+describe("checkCoverage", () => {
+  describe("uncovered", () => {
+    it("reports in-scope file with no source page", () => {
+      const r = checkCoverage(
+        cfg(["src/**/*.ts"]),
+        ["src/auth.ts"],
+        [],
+      );
+      expect(r.ok).toBe(false);
+      const v = r.violations.find((x) => x.kind === "uncovered");
+      expect(v).toBeDefined();
+      expect(v?.file).toBe("src/auth.ts");
+      expect(v?.remedy).toContain("wiki ingest");
+      expect(v?.remedy).toContain("src/auth.ts");
+    });
+
+    it("does not report excluded file as uncovered", () => {
+      const r = checkCoverage(
+        cfg(["src/**/*.ts"], [{ pattern: "src/generated/**", reason: "auto-gen" }]),
+        ["src/generated/api.ts"],
+        [],
+      );
+      expect(r.violations.filter((v) => v.kind === "uncovered")).toHaveLength(0);
+    });
+
+    it("does not report file outside includes as uncovered", () => {
+      const r = checkCoverage(cfg(["src/**/*.ts"]), ["README.md"], []);
+      expect(r.violations.filter((v) => v.kind === "uncovered")).toHaveLength(0);
+    });
+
+    it("handles nested globs correctly", () => {
+      const r = checkCoverage(
+        cfg(["src/**/*.ts"]),
+        ["src/a/b/c/deep.ts"],
+        [],
+      );
+      const v = r.violations.find((x) => x.kind === "uncovered" && x.file === "src/a/b/c/deep.ts");
+      expect(v).toBeDefined();
+    });
+
+    it("does not report in-scope file that is already ingested", () => {
+      const r = checkCoverage(
+        cfg(["src/**/*.ts"]),
+        ["src/auth.ts"],
+        [src("sources/auth.md", "src/auth.ts")],
+      );
+      expect(r.violations.filter((v) => v.kind === "uncovered")).toHaveLength(0);
+    });
+  });
+
+  describe("stale-exclusion", () => {
+    it("reports exclusion pattern that matches no project files", () => {
+      const r = checkCoverage(
+        cfg(["src/**/*.ts"], [{ pattern: "src/old/**", reason: "removed" }]),
+        ["src/auth.ts"],
+        [],
+      );
+      const v = r.violations.find((x) => x.kind === "stale-exclusion");
+      expect(v).toBeDefined();
+      expect(v?.pattern).toBe("src/old/**");
+      expect(v?.remedy).toContain("src/old/**");
+    });
+
+    it("does not report exclusion pattern that matches a file", () => {
+      const r = checkCoverage(
+        cfg(["src/**/*.ts"], [{ pattern: "src/generated/**", reason: "auto-gen" }]),
+        ["src/generated/api.ts", "src/auth.ts"],
+        [src("sources/auth.md", "src/auth.ts")],
+      );
+      expect(r.violations.filter((v) => v.kind === "stale-exclusion")).toHaveLength(0);
+    });
+  });
+
+  describe("excluded-ingested", () => {
+    it("reports source page for a file that is now excluded", () => {
+      const r = checkCoverage(
+        cfg(["src/**/*.ts"], [{ pattern: "src/generated/**", reason: "auto-gen" }]),
+        ["src/generated/api.ts"],
+        [src("sources/api.md", "src/generated/api.ts")],
+      );
+      const v = r.violations.find((x) => x.kind === "excluded-ingested");
+      expect(v).toBeDefined();
+      expect(v?.file).toBe("src/generated/api.ts");
+      expect(v?.pages).toContain("sources/api.md");
+      expect(v?.remedy).toBeDefined();
+    });
+
+    it("does not report non-excluded ingested files", () => {
+      const r = checkCoverage(
+        cfg(["src/**/*.ts"]),
+        ["src/auth.ts"],
+        [src("sources/auth.md", "src/auth.ts")],
+      );
+      expect(r.violations.filter((v) => v.kind === "excluded-ingested")).toHaveLength(0);
+    });
+  });
+
+  describe("out-of-scope", () => {
+    it("reports source page whose source_path doesn't match any include", () => {
+      const r = checkCoverage(
+        cfg(["src/**/*.ts"]),
+        ["docs/README.md"],
+        [src("sources/readme.md", "docs/README.md")],
+      );
+      const v = r.violations.find((x) => x.kind === "out-of-scope");
+      expect(v).toBeDefined();
+      expect(v?.file).toBe("docs/README.md");
+      expect(v?.pages).toContain("sources/readme.md");
+      expect(v?.remedy).toBeDefined();
+    });
+
+    it("does not report in-scope tracked source pages as out-of-scope", () => {
+      const r = checkCoverage(
+        cfg(["src/**/*.ts"]),
+        ["src/auth.ts"],
+        [src("sources/auth.md", "src/auth.ts")],
+      );
+      expect(r.violations.filter((v) => v.kind === "out-of-scope")).toHaveLength(0);
+    });
+
+    it("does not report source pages with no source_path", () => {
+      const r = checkCoverage(
+        cfg(["src/**/*.ts"]),
+        ["src/auth.ts"],
+        [src("sources/manual.md", undefined)],
+      );
+      expect(r.violations.filter((v) => v.kind === "out-of-scope")).toHaveLength(0);
+    });
+  });
+
+  describe("duplicate-source", () => {
+    it("reports multiple source pages claiming the same file", () => {
+      const r = checkCoverage(
+        cfg(["src/**/*.ts"]),
+        ["src/auth.ts"],
+        [
+          src("sources/auth.md", "src/auth.ts"),
+          src("sources/auth-v2.md", "src/auth.ts"),
+        ],
+      );
+      const v = r.violations.find((x) => x.kind === "duplicate-source");
+      expect(v).toBeDefined();
+      expect(v?.file).toBe("src/auth.ts");
+      expect(v?.pages).toHaveLength(2);
+      expect(v?.remedy).toBeDefined();
+    });
+
+    it("does not report when only one source page per file", () => {
+      const r = checkCoverage(
+        cfg(["src/**/*.ts"]),
+        ["src/auth.ts"],
+        [src("sources/auth.md", "src/auth.ts")],
+      );
+      expect(r.violations.filter((v) => v.kind === "duplicate-source")).toHaveLength(0);
+    });
+  });
+
+  describe("clean config", () => {
+    it("returns ok with no violations when fully covered", () => {
+      const r = checkCoverage(
+        cfg(["src/**/*.ts"], [{ pattern: "src/generated/**", reason: "auto-gen" }]),
+        ["src/auth.ts", "src/user.ts", "src/generated/api.ts"],
+        [
+          src("sources/auth.md", "src/auth.ts"),
+          src("sources/user.md", "src/user.ts"),
+        ],
+      );
+      expect(r.ok).toBe(true);
+      expect(r.violations).toHaveLength(0);
+    });
+  });
+
+  describe("platform path handling", () => {
+    it("normalizes backslash paths from source pages to forward slashes", () => {
+      const r = checkCoverage(
+        cfg(["src/**/*.ts"]),
+        ["src/auth.ts"],
+        [src("sources/auth.md", "src\\auth.ts")],
+      );
+      expect(r.violations.filter((v) => v.kind === "uncovered")).toHaveLength(0);
+    });
+  });
+});

--- a/wiki/SCHEMA.md
+++ b/wiki/SCHEMA.md
@@ -20,32 +20,105 @@ ${CLAUDE_PLUGIN_ROOT}/wiki-cli/bin/wiki --root ./wiki <command>
 ```
 
 Run `... help` for the full command reference. Key commands:
-- `ingest --raw <raw/path> --title <t>` (body on STDIN) — summarize a source.
+- `ingest --source <path> --title <t>` (body on STDIN) — summarize a tracked file.
+  Records `source_path` + `source_hash` for drift detection.
+  Use `--raw <label>` (legacy) when ingesting from a non-tracked input.
 - `note --type entity|concept|topic --name <n>` (body on STDIN) — synthesis page.
 - `index` — rebuild the catalog.
 - `validate` — health check (frontmatter, `[[links]]`, orphans, slug collisions, filename/title mismatches, nested pages).
-- `query <q>` — search via qmd.
+- `status` — show drift between source pages and their tracked files.
+  Use `--json` for machine-readable output (exit 1 if stale/missing).
+- `coverage` — verify declarative source coverage defined in `wiki/tracked.yaml`.
+  Fails when an in-scope file has no source page, an exclusion is stale, a file is
+  excluded yet ingested, a source page is out of scope, or multiple pages claim the
+  same file. Use `--json` for machine-readable output (exit 1 on any violation).
+- `reindex` — refresh the search index (creates the collection, or `qmd update`s it).
+- `query <q> [--limit <n>] [--chunks] [--verbatim] [--full|--snippet] [--context <chars>]` — search this wiki via qmd.
 
 ## Page conventions
 - Cross-reference pages with `[[Exact Title]]`. The CLI validates every link target exists.
 - Frontmatter is injected by the CLI — do not write it yourself.
 
 ## Operations
-- **Ingest:** user drops a file in `raw/` → you read it, discuss takeaways → call
-  `ingest` with the extracted body → then update related `notes` via `note`.
+- **Ingest (tracked):** read the source file → call `ingest --source <path> --title <t>`
+  with the summary on STDIN → then update related `notes` via `note`.
+  The CLI records a sha256 hash so drift can be detected later.
+- **Ingest (raw):** user drops a file in `raw/` → read it → call
+  `ingest --raw <raw/path> --title <t>` (no drift tracking).
 - **Query:** call `query` → read returned pages → answer with citations →
   optionally file the answer back as a `note`.
 - **Lint:** run `validate` → fix reported issues by issuing further CLI commands.
+- **Drift check:** run `status` → re-ingest stale pages with updated summaries.
+- **Coverage check:** run `coverage` → follow each violation's remedy to ingest missing files
+  or update `wiki/tracked.yaml`.
+
+## Source coverage (`wiki/tracked.yaml`)
+
+Create `wiki/tracked.yaml` to declare which project files the wiki must cover:
+
+```yaml
+include:
+  - "src/**/*.ts"
+  - "docs/**/*.md"
+exclude:
+  - pattern: "src/generated/**"
+    reason: "Auto-generated — not authored documentation"
+```
+
+- `include` — glob patterns relative to the project root. Every matching file that
+  is not excluded must have an ingested source page.
+- `exclude` — patterns with a mandatory `reason`. Each exclusion must match at least
+  one file (stale exclusions fail the check). A file that is excluded must not have
+  a source page.
+
+Run `wiki coverage` to verify. Each violation includes an actionable remedy.
+File discovery uses `git ls-files` so untracked scratch files in a worktree do not
+create false failures.
+
+## Auto-Sync (drift detection)
+
+A SessionStart hook runs `wiki status` at session start. If any source page is
+out of date (the tracked file changed since last ingest), it prints:
+
+```
+[ymir] Wiki out of date. Re-ingest these to match current files:
+  - page "Auth Module"  ← src/auth.ts (changed)
+For each: read the file, then run:
+  wiki --root ./wiki ingest --source <path> --title "<page title>"
+```
+
+Source pages that have no `source_hash` (ingested with `--raw`, or older pages)
+are "untracked" and never reported stale. You can ignore them or re-ingest with
+`--source` to opt them in to drift detection.
 
 ## Search (qmd) setup
-One-time, on this machine:
+Indexing is automatic: every `ingest`, `note`, and `index` calls `reindex`,
+which registers the collection on first use and `qmd update`s it thereafter. No
+manual setup step is needed; run `wiki reindex` yourself only to force a refresh.
 
-```
-qmd collection add ./wiki --name dogfood-wiki-wiki
-```
+`wiki query "..."` shells out to `qmd search --json -c ymir-wiki`. The
+`-c` scope matters: without it qmd searches *every* collection registered on the
+machine, not just this project's wiki. Only `sources/` and `notes/` are indexed —
+`raw/` is deliberately excluded, since the raw originals outrank the curated
+summaries written from them. Use `--limit <n>` to cap results and `--chunks` to
+get every matching chunk rather than one entry per file.
 
-Then `wiki query "..."` (which shells out to `qmd search --json --files`).
 Search is keyword-only (BM25) — lightweight, no embeddings and no local LLM, so
-there is no `qmd embed` step. Re-run `qmd collection add` after adding pages to
-refresh the index. Optional tighter integration: add a `qmd` MCP server
-(`qmd mcp`) to your client.
+there is no `qmd embed` step. Because BM25 matches words rather than meaning,
+`query` first reduces your text to its content words: `"When did Melanie paint a
+sunrise?"` is searched as `melanie paint sunrise`. Asking a full question
+verbatim retrieves far worse (measured on a 19-page wiki: 0 hits vs 1, and 3
+hits vs 10). Pass `--verbatim` when you need the text exactly as typed.
+
+Each hit returns the passage around the match — whole paragraphs, bounded by the
+enclosing section — not a narrow window, so you can answer from the result
+without opening the file. A page smaller than the budget (`--context`, default
+3000 chars) comes back whole; longer pages are narrowed to the matching section.
+`--full` forces the entire page, `--snippet` gives qmd's raw window. Measured on
+this project's own wiki, answering from raw windows scored 43% where answering
+from expanded passages scored 93%.
+
+`ingest`, `note`, and `index` automatically call
+`wiki reindex` (best-effort) after each write; pass `--no-reindex` to skip.
+Run `wiki reindex` manually if the index is stale. Optional tighter integration:
+add a `qmd` MCP server (`qmd mcp`) to your client.


### PR DESCRIPTION
## Summary

- Adds `wiki/tracked.yaml` configuration: `include` globs declare which project files the wiki must cover; `exclude` rules (each requiring a non-empty `reason`) opt files out.
- Adds `wiki coverage` CLI command that enforces complete, unambiguous coverage and exits 1 on any violation.
- Five violation kinds detected: uncovered in-scope file, stale exclusion, excluded-but-ingested file, out-of-scope source page, duplicate source claim — each with an actionable remedy.
- File discovery uses `git ls-files` (falling back to filesystem walk) so untracked scratch files in a git worktree never cause false failures.
- Adds `minimatch` for robust, platform-independent glob matching including nested `**` patterns.

## Test plan

- [x] `bun test` — 169 tests pass (23 new: 19 unit tests for `checkCoverage`/`parseCoverageConfig`, 4 integration tests for `runCoverage`)
- [x] `bun run typecheck` — no errors
- [x] Nested glob coverage (`src/a/b/c/deep.ts` matched by `src/**/*.ts`)
- [x] Platform path normalization (backslash paths normalized to forward slashes)
- [x] All five violation kinds tested independently

Fixes #24