### PR TITLE
feat(wiki-cli): add first-class rename and delete lifecycle operations

### DIFF
--- a/plugins/ymir/wiki-cli/src/cli.ts
+++ b/plugins/ymir/wiki-cli/src/cli.ts
@@ -10,6 +10,8 @@ import { appendLog, type LogOp } from "./wikilog.js";
 import { validateWiki } from "./validate.js";
 import { runStatus } from "./commands/status.js";
 import { runCoverage } from "./commands/coverage.js";
+import { runRemove } from "./commands/remove.js";
+import { runRename } from "./commands/rename.js";
 import { formatMarkdown } from "./format.js";
 import { writePage, readPage, listPages } from "./store.js";
 import { wikiPaths } from "./paths.js";
@@ -196,5 +198,54 @@ program.command("reindex").action(() => {
   if (r.ok) process.stdout.write(`reindexed as "${r.name}"\n`);
   else process.stdout.write(`reindex skipped (qmd unavailable)\n`);
 });
+
+program
+  .command("remove")
+  .requiredOption("--title <title>")
+  .option("--preview", "show what would be removed without writing", false)
+  .option("--no-reindex", "skip qmd reindex after write")
+  .action((opts: { title: string; preview: boolean; reindex: boolean }) => {
+    const root = program.opts<{ root: string }>().root;
+    const today = new Date().toISOString().slice(0, 10);
+    try {
+      const result = runRemove({ root, title: opts.title, today, preview: opts.preview, noReindex: !opts.reindex });
+      if (result.inboundLinks.length > 0) {
+        for (const l of result.inboundLinks) process.stdout.write(`  inbound: ${l.from}: ${l.link}\n`);
+      }
+      if (opts.preview) {
+        process.stdout.write(`preview: would remove ${result.path}\n`);
+      } else {
+        process.stdout.write(`removed ${result.path}\n`);
+      }
+    } catch (e) {
+      process.stderr.write(`${(e as Error).message}\n`);
+      process.exit(1);
+    }
+  });
+
+program
+  .command("rename")
+  .requiredOption("--old-title <title>")
+  .requiredOption("--new-title <title>")
+  .option("--preview", "show what would change without writing", false)
+  .option("--no-reindex", "skip qmd reindex after write")
+  .action(async (opts: { oldTitle: string; newTitle: string; preview: boolean; reindex: boolean }) => {
+    const root = program.opts<{ root: string }>().root;
+    const today = new Date().toISOString().slice(0, 10);
+    try {
+      const result = await runRename({ root, oldTitle: opts.oldTitle, newTitle: opts.newTitle, today, preview: opts.preview, noReindex: !opts.reindex });
+      if (opts.preview) {
+        process.stdout.write(`preview: would rename "${opts.oldTitle}" → "${opts.newTitle}"\n`);
+        process.stdout.write(`  links to update: ${result.linksUpdated}\n`);
+        for (const p of result.affectedPaths) process.stdout.write(`  ${p}\n`);
+      } else {
+        process.stdout.write(`renamed "${opts.oldTitle}" → "${opts.newTitle}"\n`);
+        if (result.linksUpdated > 0) process.stdout.write(`  updated ${result.linksUpdated} link(s)\n`);
+      }
+    } catch (e) {
+      process.stderr.write(`${(e as Error).message}\n`);
+      process.exit(1);
+    }
+  });
 
 program.parseAsync();

--- a/plugins/ymir/wiki-cli/src/commands/help.ts
+++ b/plugins/ymir/wiki-cli/src/commands/help.ts
@@ -10,6 +10,13 @@ Commands:
                                       Create/update a synthesis note. Body from STDIN.
   index                               Rebuild index.md from all pages.
   log <op> <title>                    Append a dated entry to log.md.
+  remove --title <t> [--preview]       Delete a source or note and rebuild all generated state.
+                                      Refuses if inbound [[links]] exist — fix those first.
+                                      --preview: report impact without writing.
+  rename --old-title <t> --new-title <t> [--preview]
+                                      Rename a page, rewrite all inbound [[links]], and
+                                      rebuild generated state atomically.
+                                      --preview: show link count and affected paths.
   validate                            Check frontmatter, [[links]], orphans, slug collisions,
                                       filename/title mismatches, and nested pages.
                                       Exit !=0 on error.

--- a/plugins/ymir/wiki-cli/src/commands/remove.ts
+++ b/plugins/ymir/wiki-cli/src/commands/remove.ts
@@ -1,0 +1,80 @@
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { listPages, readPage, writePage } from "../store.js";
+import { sourcePath, notePath, wikiPaths, slugify } from "../paths.js";
+import { buildIndex } from "../index-build.js";
+import { appendLog } from "../wikilog.js";
+import { parseFrontmatter } from "../frontmatter.js";
+import { reindex, type ReindexRunner } from "../reindex.js";
+
+export interface InboundLink {
+  from: string;
+  link: string;
+}
+
+export interface RemoveInput {
+  root: string;
+  title: string;
+  today: string;
+  noReindex?: boolean;
+  preview?: boolean;
+  reindexRunner?: ReindexRunner;
+}
+
+export interface RemoveResult {
+  path: string;
+  inboundLinks: InboundLink[];
+  removed: boolean;
+}
+
+function findPage(root: string, title: string): string | null {
+  for (const sub of ["sources", "notes"] as const) {
+    const candidate = sub === "sources" ? sourcePath(root, title) : notePath(root, title);
+    if (!existsSync(candidate)) continue;
+    const fm = parseFrontmatter(readPage(candidate)).data as { title?: string };
+    if (fm.title === title) return candidate;
+  }
+  return null;
+}
+
+function scanInboundLinks(root: string, title: string, excludePath: string): InboundLink[] {
+  const targetSlug = slugify(title);
+  const results: InboundLink[] = [];
+  for (const sub of ["sources", "notes"] as const) {
+    const dir = join(root, sub);
+    for (const file of listPages(dir)) {
+      const abs = join(dir, file);
+      if (abs === excludePath) continue;
+      const { content } = parseFrontmatter(readPage(abs));
+      const rel = `${sub}/${file}`;
+      for (const m of content.matchAll(/\[\[([^\]]+)\]\]/g)) {
+        if (slugify(m[1]!.trim()) === targetSlug) {
+          results.push({ from: rel, link: `[[${m[1]!.trim()}]]` });
+        }
+      }
+    }
+  }
+  return results;
+}
+
+export function runRemove(i: RemoveInput): RemoveResult {
+  const path = findPage(i.root, i.title);
+  if (!path) throw new Error(`remove rejected: "${i.title}" not found`);
+
+  const inboundLinks = scanInboundLinks(i.root, i.title, path);
+
+  if (i.preview) return { path, inboundLinks, removed: false };
+
+  if (inboundLinks.length > 0) {
+    const detail = inboundLinks.map((l) => `  ${l.from}: ${l.link}`).join("\n");
+    throw new Error(`remove rejected: inbound link(s) would break — remove or update them first:\n${detail}`);
+  }
+
+  rmSync(path);
+
+  writePage(wikiPaths(i.root).index, buildIndex(i.root));
+  appendLog(i.root, "remove", i.title, i.today);
+  if (!i.noReindex) reindex(i.root, i.reindexRunner);
+
+  return { path, inboundLinks, removed: true };
+}

--- a/plugins/ymir/wiki-cli/src/commands/rename.ts
+++ b/plugins/ymir/wiki-cli/src/commands/rename.ts
@@ -1,0 +1,138 @@
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { listPages, readPage, writePage } from "../store.js";
+import { sourcePath, notePath, wikiPaths, slugify } from "../paths.js";
+import { buildIndex } from "../index-build.js";
+import { appendLog } from "../wikilog.js";
+import { parseFrontmatter, stringifyFrontmatter } from "../frontmatter.js";
+import { validateWiki } from "../validate.js";
+import { reindex, type ReindexRunner } from "../reindex.js";
+
+export interface RenameInput {
+  root: string;
+  oldTitle: string;
+  newTitle: string;
+  today: string;
+  noReindex?: boolean;
+  preview?: boolean;
+  reindexRunner?: ReindexRunner;
+}
+
+export interface RenameResult {
+  oldPath: string;
+  newPath: string;
+  linksUpdated: number;
+  affectedPaths: string[];
+  renamed: boolean;
+}
+
+type SubDir = "sources" | "notes";
+
+interface FoundPage {
+  path: string;
+  sub: SubDir;
+}
+
+function findPage(root: string, title: string): FoundPage | null {
+  for (const sub of ["sources", "notes"] as SubDir[]) {
+    const candidate = sub === "sources" ? sourcePath(root, title) : notePath(root, title);
+    if (!existsSync(candidate)) continue;
+    const fm = parseFrontmatter(readPage(candidate)).data as { title?: string };
+    if (fm.title === title) return { path: candidate, sub };
+  }
+  return null;
+}
+
+function newPath(root: string, sub: SubDir, title: string): string {
+  return sub === "sources" ? sourcePath(root, title) : notePath(root, title);
+}
+
+function rewriteLinks(content: string, oldSlug: string, newTitle: string): { updated: string; count: number } {
+  let count = 0;
+  const updated = content.replace(/\[\[([^\]]+)\]\]/g, (_match, inner: string) => {
+    if (slugify(inner.trim()) === oldSlug) {
+      count++;
+      return `[[${newTitle}]]`;
+    }
+    return _match;
+  });
+  return { updated, count };
+}
+
+export async function runRename(i: RenameInput): Promise<RenameResult> {
+  const found = findPage(i.root, i.oldTitle);
+  if (!found) throw new Error(`rename rejected: "${i.oldTitle}" not found`);
+
+  const targetPath = newPath(i.root, found.sub, i.newTitle);
+  const newSlug = slugify(i.newTitle);
+  const oldSlug = slugify(i.oldTitle);
+
+  if (newSlug !== oldSlug && existsSync(targetPath)) {
+    const existingTitle = (parseFrontmatter(readPage(targetPath)).data as { title?: string }).title;
+    throw new Error(
+      `rename rejected: slug collision — "${targetPath}" already holds "${existingTitle}"`,
+    );
+  }
+
+  const oldSlugNorm = slugify(i.oldTitle);
+  let linksUpdated = 0;
+  const affectedPaths: string[] = [];
+
+  for (const sub of ["sources", "notes"] as SubDir[]) {
+    const dir = join(i.root, sub);
+    for (const file of listPages(dir)) {
+      const abs = join(dir, file);
+      const { data, content } = parseFrontmatter(readPage(abs));
+      const { count } = rewriteLinks(content, oldSlugNorm, i.newTitle);
+      if (count > 0) {
+        linksUpdated += count;
+        affectedPaths.push(abs);
+      }
+    }
+  }
+
+  if (i.preview) return { oldPath: found.path, newPath: targetPath, linksUpdated, affectedPaths, renamed: false };
+
+  const snapshots = new Map<string, string>();
+
+  const applyLinkUpdates = (): void => {
+    for (const sub of ["sources", "notes"] as SubDir[]) {
+      const dir = join(i.root, sub);
+      for (const file of listPages(dir)) {
+        const abs = join(dir, file);
+        const raw = readPage(abs);
+        snapshots.set(abs, raw);
+        const { data, content } = parseFrontmatter(raw);
+        const { updated } = rewriteLinks(content, oldSlugNorm, i.newTitle);
+        if (updated !== content) writePage(abs, stringifyFrontmatter(updated, data));
+      }
+    }
+  };
+
+  const restore = (): void => {
+    for (const [abs, content] of snapshots) writePage(abs, content);
+    if (existsSync(targetPath) && targetPath !== found.path) rmSync(targetPath);
+  };
+
+  applyLinkUpdates();
+
+  const oldRaw = snapshots.get(found.path) ?? readPage(found.path);
+  const { data: oldData, content: oldContent } = parseFrontmatter(oldRaw);
+  const renamedData = { ...oldData, title: i.newTitle };
+  const { updated: renamedContent } = rewriteLinks(oldContent, oldSlugNorm, i.newTitle);
+  writePage(targetPath, stringifyFrontmatter(renamedContent, renamedData));
+
+  if (found.path !== targetPath) rmSync(found.path);
+
+  const result = validateWiki(i.root);
+  if (!result.ok) {
+    restore();
+    throw new Error(`rename rejected:\n${result.errors.join("\n")}`);
+  }
+
+  writePage(wikiPaths(i.root).index, buildIndex(i.root));
+  appendLog(i.root, "rename", `${i.oldTitle} → ${i.newTitle}`, i.today);
+  if (!i.noReindex) reindex(i.root, i.reindexRunner);
+
+  return { oldPath: found.path, newPath: targetPath, linksUpdated, affectedPaths, renamed: true };
+}

--- a/plugins/ymir/wiki-cli/src/templates/wiki/SCHEMA.md
+++ b/plugins/ymir/wiki-cli/src/templates/wiki/SCHEMA.md
@@ -32,6 +32,12 @@ Run `... help` for the full command reference. Key commands:
   Fails when an in-scope file has no source page, an exclusion is stale, a file is
   excluded yet ingested, a source page is out of scope, or multiple pages claim the
   same file. Use `--json` for machine-readable output (exit 1 on any violation).
+- `remove --title <t> [--preview]` — atomically delete a page and rebuild all generated state.
+  Refuses if any page holds an inbound `[[link]]` to the target — fix those first.
+  `--preview` reports what would be removed and lists inbound links without writing.
+- `rename --old-title <t> --new-title <t> [--preview]` — rename a page, rewrite all inbound
+  `[[links]]`, and rebuild generated state atomically. Fails on slug collision.
+  `--preview` reports the plan (link count, affected paths) without writing.
 - `reindex` — refresh the search index (creates the collection, or `qmd update`s it).
 - `query <q> [--limit <n>] [--chunks] [--verbatim] [--full|--snippet] [--context <chars>]` — search this wiki via qmd.
 
@@ -51,6 +57,12 @@ Run `... help` for the full command reference. Key commands:
 - **Drift check:** run `status` → re-ingest stale pages with updated summaries.
 - **Coverage check:** run `coverage` → follow each violation's remedy to ingest missing files
   or update `wiki/tracked.yaml`.
+- **Remove a page:** run `remove --title <t> --preview` to see inbound links and confirm no
+  breakage, then run `remove --title <t>` to delete the page and rebuild the index.
+  If inbound links exist, update or remove them first, then retry.
+- **Rename a page:** run `rename --old-title <t> --new-title <t> --preview` to see the scope
+  of link rewrites, then run `rename --old-title <t> --new-title <t>` to apply atomically.
+  All `[[old title]]` links in sources and notes are rewritten to `[[new title]]` in one step.
 
 ## Source coverage (`wiki/tracked.yaml`)
 

--- a/plugins/ymir/wiki-cli/src/wikilog.ts
+++ b/plugins/ymir/wiki-cli/src/wikilog.ts
@@ -1,7 +1,7 @@
 import { appendFileLine } from "./store.js";
 import { wikiPaths } from "./paths.js";
 
-export type LogOp = "ingest" | "note" | "index" | "query" | "lint";
+export type LogOp = "ingest" | "note" | "index" | "query" | "lint" | "remove" | "rename";
 
 export function appendLog(root: string, op: LogOp, title: string, date: string): void {
   appendFileLine(wikiPaths(root).log, `## [${date}] ${op} | ${title}`);

--- a/plugins/ymir/wiki-cli/test/remove.test.ts
+++ b/plugins/ymir/wiki-cli/test/remove.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { mkdtempSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readPage } from "../src/store.js";
+import { runIngest } from "../src/commands/ingest.js";
+import { runNote } from "../src/commands/note.js";
+import { runRemove } from "../src/commands/remove.js";
+
+const noReindex = true;
+
+let root: string;
+beforeEach(() => { root = mkdtempSync(join(tmpdir(), "wiki-")); });
+
+describe("runRemove", () => {
+  it("removes a source page and rebuilds index and appends log", async () => {
+    await runIngest({ root, raw: "raw/a.pdf", title: "Doc A", body: "Content.", today: "2026-08-18", noReindex });
+
+    const result = runRemove({ root, title: "Doc A", today: "2026-08-18", noReindex });
+
+    expect(result.removed).toBe(true);
+    expect(result.inboundLinks).toHaveLength(0);
+    expect(existsSync(join(root, "sources", "doc-a.md"))).toBe(false);
+    expect(readPage(join(root, "index.md"))).not.toContain("[Doc A]");
+    expect(readPage(join(root, "log.md"))).toContain("## [2026-08-18] remove | Doc A");
+  });
+
+  it("removes a note page that has no inbound links", async () => {
+    await runNote({ root, type: "entity", name: "My Note", body: "Details.", today: "2026-08-18", noReindex });
+
+    const result = runRemove({ root, title: "My Note", today: "2026-08-18", noReindex });
+
+    expect(result.removed).toBe(true);
+    expect(existsSync(join(root, "notes", "my-note.md"))).toBe(false);
+    expect(readPage(join(root, "index.md"))).not.toContain("[My Note]");
+  });
+
+  it("throws and leaves wiki unchanged when inbound links exist", async () => {
+    await runIngest({ root, raw: "raw/b.pdf", title: "Doc B", body: "Content.", today: "2026-08-18", noReindex });
+    await runIngest({ root, raw: "raw/a.pdf", title: "Doc A", body: "See [[Doc B]].", today: "2026-08-18", noReindex });
+
+    const prevDocB = readPage(join(root, "sources", "doc-b.md"));
+
+    expect(() => runRemove({ root, title: "Doc B", today: "2026-08-18", noReindex })).toThrow(/inbound link/);
+    expect(readPage(join(root, "sources", "doc-b.md"))).toBe(prevDocB);
+  });
+
+  it("reports inbound links in the thrown error", async () => {
+    await runIngest({ root, raw: "raw/b.pdf", title: "Doc B", body: "Content.", today: "2026-08-18", noReindex });
+    await runIngest({ root, raw: "raw/a.pdf", title: "Doc A", body: "See [[Doc B]].", today: "2026-08-18", noReindex });
+
+    let err: Error | undefined;
+    try { runRemove({ root, title: "Doc B", today: "2026-08-18", noReindex }); }
+    catch (e) { err = e as Error; }
+
+    expect(err?.message).toContain("sources/doc-a.md");
+    expect(err?.message).toContain("[[Doc B]]");
+  });
+
+  it("throws when page does not exist", () => {
+    expect(() => runRemove({ root, title: "Ghost", today: "2026-08-18", noReindex })).toThrow(/not found/);
+  });
+
+  it("preview mode returns plan without mutating files", async () => {
+    await runIngest({ root, raw: "raw/a.pdf", title: "Doc A", body: "Content.", today: "2026-08-18", noReindex });
+
+    const result = runRemove({ root, title: "Doc A", today: "2026-08-18", noReindex, preview: true });
+
+    expect(result.removed).toBe(false);
+    expect(existsSync(join(root, "sources", "doc-a.md"))).toBe(true);
+  });
+
+  it("preview mode reports inbound links without throwing", async () => {
+    await runIngest({ root, raw: "raw/b.pdf", title: "Doc B", body: "Content.", today: "2026-08-18", noReindex });
+    await runIngest({ root, raw: "raw/a.pdf", title: "Doc A", body: "See [[Doc B]].", today: "2026-08-18", noReindex });
+
+    const result = runRemove({ root, title: "Doc B", today: "2026-08-18", noReindex, preview: true });
+
+    expect(result.removed).toBe(false);
+    expect(result.inboundLinks.length).toBeGreaterThan(0);
+    expect(result.inboundLinks[0]!.from).toContain("doc-a");
+  });
+});

--- a/plugins/ymir/wiki-cli/test/rename.test.ts
+++ b/plugins/ymir/wiki-cli/test/rename.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { mkdtempSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readPage } from "../src/store.js";
+import { runIngest } from "../src/commands/ingest.js";
+import { runNote } from "../src/commands/note.js";
+import { runRename } from "../src/commands/rename.js";
+
+const noReindex = true;
+
+let root: string;
+beforeEach(() => { root = mkdtempSync(join(tmpdir(), "wiki-")); });
+
+describe("runRename", () => {
+  it("renames a source page: new file exists, old file gone, index updated, log appended", async () => {
+    await runIngest({ root, raw: "raw/a.pdf", title: "Old Name", body: "Content.", today: "2026-08-18", noReindex });
+
+    const result = await runRename({ root, oldTitle: "Old Name", newTitle: "New Name", today: "2026-08-18", noReindex });
+
+    expect(result.renamed).toBe(true);
+    expect(existsSync(join(root, "sources", "new-name.md"))).toBe(true);
+    expect(existsSync(join(root, "sources", "old-name.md"))).toBe(false);
+    expect(readPage(join(root, "sources", "new-name.md"))).toContain("title: New Name");
+    expect(readPage(join(root, "index.md"))).toContain("[New Name](sources/new-name.md)");
+    expect(readPage(join(root, "index.md"))).not.toContain("[Old Name]");
+    expect(readPage(join(root, "log.md"))).toContain("## [2026-08-18] rename | Old Name → New Name");
+  });
+
+  it("updates inbound wiki links in other pages to the new title", async () => {
+    await runIngest({ root, raw: "raw/a.pdf", title: "Old Name", body: "Content.", today: "2026-08-18", noReindex });
+    await runIngest({ root, raw: "raw/b.pdf", title: "Ref Page", body: "See [[Old Name]] here.", today: "2026-08-18", noReindex });
+
+    await runRename({ root, oldTitle: "Old Name", newTitle: "New Name", today: "2026-08-18", noReindex });
+
+    expect(readPage(join(root, "sources", "ref-page.md"))).toContain("[[New Name]]");
+    expect(readPage(join(root, "sources", "ref-page.md"))).not.toContain("[[Old Name]]");
+  });
+
+  it("renames a note page", async () => {
+    await runNote({ root, type: "concept", name: "My Concept", body: "Details.", today: "2026-08-18", noReindex });
+    await runIngest({ root, raw: "raw/a.pdf", title: "Doc A", body: "See [[My Concept]].", today: "2026-08-18", noReindex });
+
+    await runRename({ root, oldTitle: "My Concept", newTitle: "Better Concept", today: "2026-08-18", noReindex });
+
+    expect(existsSync(join(root, "notes", "better-concept.md"))).toBe(true);
+    expect(existsSync(join(root, "notes", "my-concept.md"))).toBe(false);
+    expect(readPage(join(root, "sources", "doc-a.md"))).toContain("[[Better Concept]]");
+  });
+
+  it("rejects rename when old page does not exist", async () => {
+    await expect(runRename({ root, oldTitle: "Ghost", newTitle: "Real", today: "2026-08-18", noReindex })).rejects.toThrow(/not found/);
+  });
+
+  it("rejects rename when new title slug collides with a different page", async () => {
+    await runIngest({ root, raw: "raw/a.pdf", title: "Doc A", body: "Content.", today: "2026-08-18", noReindex });
+    await runIngest({ root, raw: "raw/b.pdf", title: "Doc B", body: "Content.", today: "2026-08-18", noReindex });
+
+    await expect(runRename({ root, oldTitle: "Doc A", newTitle: "Doc B", today: "2026-08-18", noReindex })).rejects.toThrow(/collision/);
+    expect(existsSync(join(root, "sources", "doc-a.md"))).toBe(true);
+    expect(existsSync(join(root, "sources", "doc-b.md"))).toBe(true);
+  });
+
+  it("updates self-references when renaming a self-linking page", async () => {
+    await runIngest({ root, raw: "raw/a.pdf", title: "Doc A", body: "See [[Doc A]].", today: "2026-08-18", noReindex });
+
+    await runRename({ root, oldTitle: "Doc A", newTitle: "Doc B", today: "2026-08-18", noReindex });
+
+    const content = readPage(join(root, "sources", "doc-b.md"));
+    expect(content).toContain("[[Doc B]]");
+    expect(content).not.toContain("[[Doc A]]");
+  });
+
+  it("preview mode returns plan and counts updated links without mutating files", async () => {
+    await runIngest({ root, raw: "raw/a.pdf", title: "Old Name", body: "Content.", today: "2026-08-18", noReindex });
+    await runIngest({ root, raw: "raw/b.pdf", title: "Ref Page", body: "See [[Old Name]].", today: "2026-08-18", noReindex });
+
+    const result = await runRename({ root, oldTitle: "Old Name", newTitle: "New Name", today: "2026-08-18", noReindex, preview: true });
+
+    expect(result.renamed).toBe(false);
+    expect(result.linksUpdated).toBe(1);
+    expect(existsSync(join(root, "sources", "old-name.md"))).toBe(true);
+    expect(existsSync(join(root, "sources", "new-name.md"))).toBe(false);
+  });
+
+  it("reports the paths of files where inbound links would be updated", async () => {
+    await runIngest({ root, raw: "raw/a.pdf", title: "Old Name", body: "Content.", today: "2026-08-18", noReindex });
+    await runIngest({ root, raw: "raw/b.pdf", title: "Ref Page", body: "See [[Old Name]].", today: "2026-08-18", noReindex });
+
+    const result = await runRename({ root, oldTitle: "Old Name", newTitle: "New Name", today: "2026-08-18", noReindex, preview: true });
+
+    expect(result.affectedPaths).toContain(join(root, "sources", "ref-page.md"));
+  });
+});

--- a/wiki/SCHEMA.md
+++ b/wiki/SCHEMA.md
@@ -32,6 +32,12 @@ Run `... help` for the full command reference. Key commands:
   Fails when an in-scope file has no source page, an exclusion is stale, a file is
   excluded yet ingested, a source page is out of scope, or multiple pages claim the
   same file. Use `--json` for machine-readable output (exit 1 on any violation).
+- `remove --title <t> [--preview]` — atomically delete a page and rebuild all generated state.
+  Refuses if any page holds an inbound `[[link]]` to the target — fix those first.
+  `--preview` reports what would be removed and lists inbound links without writing.
+- `rename --old-title <t> --new-title <t> [--preview]` — rename a page, rewrite all inbound
+  `[[links]]`, and rebuild generated state atomically. Fails on slug collision.
+  `--preview` reports the plan (link count, affected paths) without writing.
 - `reindex` — refresh the search index (creates the collection, or `qmd update`s it).
 - `query <q> [--limit <n>] [--chunks] [--verbatim] [--full|--snippet] [--context <chars>]` — search this wiki via qmd.
 
@@ -51,6 +57,12 @@ Run `... help` for the full command reference. Key commands:
 - **Drift check:** run `status` → re-ingest stale pages with updated summaries.
 - **Coverage check:** run `coverage` → follow each violation's remedy to ingest missing files
   or update `wiki/tracked.yaml`.
+- **Remove a page:** run `remove --title <t> --preview` to see inbound links and confirm no
+  breakage, then run `remove --title <t>` to delete the page and rebuild the index.
+  If inbound links exist, update or remove them first, then retry.
+- **Rename a page:** run `rename --old-title <t> --new-title <t> --preview` to see the scope
+  of link rewrites, then run `rename --old-title <t> --new-title <t>` to apply atomically.
+  All `[[old title]]` links in sources and notes are rewritten to `[[new title]]` in one step.
 
 ## Source coverage (`wiki/tracked.yaml`)
 


### PR DESCRIPTION
## Summary

- Adds `wiki remove --title <t>` to atomically delete a source or note, refusing when inbound `[[links]]` exist and reporting them so they can be fixed first. `--preview` mode shows impact without writing.
- Adds `wiki rename --old-title <t> --new-title <t>` to rename a page, rewrite all inbound `[[links]]` across sources and notes, and rebuild generated state atomically. Rejects slug collisions and rolls back on validation failure. `--preview` mode shows the link count and affected paths without writing.
- Extends `LogOp` type with `"remove"` and `"rename"` entries.
- Documents both commands in `help` text, the template `SCHEMA.md`, and `wiki/SCHEMA.md`.

## Test plan

- [ ] 7 new tests for `runRemove` covering happy path, note removal, inbound-link rejection (with error detail), not-found, and preview mode
- [ ] 8 new tests for `runRename` covering happy path, inbound-link rewriting, note rename, not-found, slug collision, self-reference update, and preview mode
- [ ] Full suite (184 tests) passes, typecheck clean

Fixes #25