### PR TITLE
feat(wiki-cli): add wiki check command as single policy-aware CI gate

### DIFF
--- a/plugins/ymir/wiki-cli/src/check.ts
+++ b/plugins/ymir/wiki-cli/src/check.ts
@@ -1,0 +1,185 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { validateWiki } from "./validate.js";
+import { computeStatus } from "./status.js";
+import { loadCoverageConfig, collectProjectFiles, loadSourcePages, checkCoverage } from "./coverage.js";
+import { buildIndex } from "./index-build.js";
+import { wikiPaths } from "./paths.js";
+
+export type CheckKind =
+  | "schema-invalid"
+  | "nested-page"
+  | "filename-mismatch"
+  | "slug-collision"
+  | "broken-link"
+  | "orphan-note"
+  | "stale-source"
+  | "missing-source"
+  | "untracked-source"
+  | "coverage-uncovered"
+  | "coverage-stale-exclusion"
+  | "coverage-excluded-ingested"
+  | "coverage-out-of-scope"
+  | "coverage-duplicate-source"
+  | "stale-index";
+
+export interface CheckFinding {
+  kind: CheckKind;
+  path?: string;
+  message: string;
+  remedy?: string;
+}
+
+export interface CheckReport {
+  ok: boolean;
+  errors: CheckFinding[];
+  warnings: CheckFinding[];
+}
+
+export interface CheckOptions {
+  root: string;
+  errorOnOrphanNotes?: boolean;
+  errorOnUntrackedSources?: boolean;
+}
+
+function classifyValidateErrors(errors: string[]): CheckFinding[] {
+  return errors.map((msg) => {
+    const kind = inferValidateKind(msg);
+    const path = extractPath(msg);
+    return { kind, path, message: msg, remedy: extractRemedy(msg) };
+  });
+}
+
+function inferValidateKind(msg: string): CheckKind {
+  if (msg.includes("invalid frontmatter")) return "schema-invalid";
+  if (msg.includes("nested page")) return "nested-page";
+  if (msg.includes("filename")) return "filename-mismatch";
+  if (msg.includes("slug collision")) return "slug-collision";
+  if (msg.includes("broken link")) return "broken-link";
+  return "schema-invalid";
+}
+
+function extractPath(msg: string): string | undefined {
+  const m = /^((?:sources|notes)\/[^:]+):/.exec(msg);
+  return m ? m[1] : undefined;
+}
+
+function extractRemedy(msg: string): string | undefined {
+  const m = /— (.+)$/.exec(msg);
+  return m ? m[1] : undefined;
+}
+
+function checkIndexFreshness(root: string): CheckFinding | null {
+  const indexPath = wikiPaths(root).index;
+  if (!existsSync(indexPath)) {
+    return {
+      kind: "stale-index",
+      path: "index.md",
+      message: "index.md is missing",
+      remedy: "run: wiki index",
+    };
+  }
+  const current = readFileSync(indexPath, "utf8");
+  const expected = buildIndex(root);
+  if (current !== expected) {
+    return {
+      kind: "stale-index",
+      path: "index.md",
+      message: "index.md is out of date",
+      remedy: "run: wiki index",
+    };
+  }
+  return null;
+}
+
+export function runCheck(opts: CheckOptions): CheckReport {
+  const { root, errorOnOrphanNotes = false, errorOnUntrackedSources = false } = opts;
+
+  const errors: CheckFinding[] = [];
+  const warnings: CheckFinding[] = [];
+
+  const validation = validateWiki(root);
+  errors.push(...classifyValidateErrors(validation.errors));
+
+  for (const w of validation.warnings) {
+    const finding: CheckFinding = {
+      kind: "orphan-note",
+      path: extractOrphanPath(w),
+      message: w,
+      remedy: "add a link to this note from a source or another note",
+    };
+    if (errorOnOrphanNotes) errors.push(finding);
+    else warnings.push(finding);
+  }
+
+  const status = computeStatus(root);
+  for (const s of status.sources) {
+    if (s.state === "stale") {
+      errors.push({
+        kind: "stale-source",
+        path: s.rel,
+        message: `stale source: ${s.title} ← ${s.source_path} (changed)`,
+        remedy: `re-ingest from ${s.source_path}`,
+      });
+    } else if (s.state === "missing") {
+      errors.push({
+        kind: "missing-source",
+        path: s.rel,
+        message: `missing source: ${s.title} ← ${s.source_path ?? "(unknown)"} (not found)`,
+        remedy: `update source_path or remove the source page`,
+      });
+    } else if (s.state === "untracked") {
+      const finding: CheckFinding = {
+        kind: "untracked-source",
+        path: s.rel,
+        message: `untracked source: ${s.title} (no source_path recorded)`,
+        remedy: `re-ingest with --source <file> to record provenance`,
+      };
+      if (errorOnUntrackedSources) errors.push(finding);
+      else warnings.push(finding);
+    }
+  }
+
+  const projectRoot = resolve(root, "..");
+  const coverageConfig = loadCoverageConfig(root);
+  if (coverageConfig) {
+    const projectFiles = collectProjectFiles(projectRoot);
+    const paths = wikiPaths(root);
+    const sourcePages = loadSourcePages(paths.sourcesDir);
+    const coverage = checkCoverage(coverageConfig, projectFiles, sourcePages);
+    for (const v of coverage.violations) {
+      errors.push({
+        kind: `coverage-${v.kind}` as CheckKind,
+        path: v.file,
+        message: formatCoverageViolation(v.kind, v.file, v.pattern, v.pages),
+        remedy: v.remedy,
+      });
+    }
+  }
+
+  const indexFinding = checkIndexFreshness(root);
+  if (indexFinding) errors.push(indexFinding);
+
+  return { ok: errors.length === 0, errors, warnings };
+}
+
+function extractOrphanPath(msg: string): string | undefined {
+  const m = /orphan note: (notes\/[^\s(]+)/.exec(msg);
+  return m ? m[1] : undefined;
+}
+
+function formatCoverageViolation(
+  kind: string,
+  file?: string,
+  pattern?: string,
+  pages?: string[],
+): string {
+  switch (kind) {
+    case "uncovered": return `uncovered: ${file}`;
+    case "stale-exclusion": return `stale exclusion pattern: "${pattern}"`;
+    case "excluded-ingested": return `excluded but ingested: ${file} (${pages?.join(", ")})`;
+    case "out-of-scope": return `out-of-scope source page: ${file} (${pages?.join(", ")})`;
+    case "duplicate-source": return `duplicate source: ${file} claimed by ${pages?.join(", ")}`;
+    default: return `coverage violation: ${file ?? pattern}`;
+  }
+}

--- a/plugins/ymir/wiki-cli/src/cli.ts
+++ b/plugins/ymir/wiki-cli/src/cli.ts
@@ -10,6 +10,7 @@ import { appendLog, type LogOp } from "./wikilog.js";
 import { validateWiki } from "./validate.js";
 import { runStatus } from "./commands/status.js";
 import { runCoverage } from "./commands/coverage.js";
+import { runCheckCmd } from "./commands/check.js";
 import { runRemove } from "./commands/remove.js";
 import { runRename } from "./commands/rename.js";
 import { formatMarkdown } from "./format.js";
@@ -188,6 +189,23 @@ program
   .action((opts: { json: boolean }) => {
     const root = program.opts<{ root: string }>().root;
     const { text, exitCode } = runCoverage({ root, json: opts.json });
+    process.stdout.write(text);
+    if (exitCode !== 0) process.exit(exitCode);
+  });
+
+program
+  .command("check")
+  .option("--json", "emit JSON output", false)
+  .option("--error-on-orphan-notes", "treat orphan notes as hard failures", false)
+  .option("--error-on-untracked-sources", "treat untracked sources as hard failures", false)
+  .action((opts: { json: boolean; errorOnOrphanNotes: boolean; errorOnUntrackedSources: boolean }) => {
+    const root = program.opts<{ root: string }>().root;
+    const { text, exitCode } = runCheckCmd({
+      root,
+      json: opts.json,
+      errorOnOrphanNotes: opts.errorOnOrphanNotes,
+      errorOnUntrackedSources: opts.errorOnUntrackedSources,
+    });
     process.stdout.write(text);
     if (exitCode !== 0) process.exit(exitCode);
   });

--- a/plugins/ymir/wiki-cli/src/commands/check.ts
+++ b/plugins/ymir/wiki-cli/src/commands/check.ts
@@ -1,0 +1,38 @@
+import { runCheck, type CheckFinding } from "../check.js";
+
+export interface CheckCmdInput {
+  root: string;
+  json: boolean;
+  errorOnOrphanNotes: boolean;
+  errorOnUntrackedSources: boolean;
+}
+
+export interface CheckCmdOutput {
+  text: string;
+  exitCode: number;
+}
+
+function formatFinding(prefix: string, f: CheckFinding): string {
+  const loc = f.path ? ` ${f.path}` : "";
+  const remedy = f.remedy ? `\n  remedy: ${f.remedy}` : "";
+  return `${prefix}:${loc}: ${f.message}${remedy}`;
+}
+
+export function runCheckCmd(i: CheckCmdInput): CheckCmdOutput {
+  const report = runCheck({
+    root: i.root,
+    errorOnOrphanNotes: i.errorOnOrphanNotes,
+    errorOnUntrackedSources: i.errorOnUntrackedSources,
+  });
+
+  if (i.json) {
+    return { text: JSON.stringify(report, null, 2) + "\n", exitCode: report.ok ? 0 : 1 };
+  }
+
+  const lines: string[] = [];
+  for (const e of report.errors) lines.push(formatFinding("error", e));
+  for (const w of report.warnings) lines.push(formatFinding("warning", w));
+  if (report.ok) lines.push("wiki ok");
+
+  return { text: lines.join("\n") + "\n", exitCode: report.ok ? 0 : 1 };
+}

--- a/plugins/ymir/wiki-cli/src/templates/wiki/SCHEMA.md
+++ b/plugins/ymir/wiki-cli/src/templates/wiki/SCHEMA.md
@@ -25,6 +25,13 @@ Run `... help` for the full command reference. Key commands:
   Use `--raw <label>` (legacy) when ingesting from a non-tracked input.
 - `note --type entity|concept|topic --name <n>` (body on STDIN) — synthesis page.
 - `index` — rebuild the catalog.
+- `check [--json] [--error-on-orphan-notes] [--error-on-untracked-sources]` — single CI gate.
+  Evaluates schema validity, page identity, broken links, orphan policy, provenance drift,
+  untracked sources, declarative coverage, and index freshness in one read-only pass.
+  Exits non-zero on any hard failure; zero only when the wiki satisfies policy.
+  Orphan notes and untracked sources are warnings by default; promote to errors with the
+  respective flags. Use `--json` for machine-readable output with stable schema
+  `{ ok, errors[], warnings[] }`, each finding carrying `kind`, `message`, and `remedy`.
 - `validate` — health check (frontmatter, `[[links]]`, orphans, slug collisions, filename/title mismatches, nested pages).
 - `status` — show drift between source pages and their tracked files.
   Use `--json` for machine-readable output (exit 1 if stale/missing).
@@ -53,6 +60,8 @@ Run `... help` for the full command reference. Key commands:
   `ingest --raw <raw/path> --title <t>` (no drift tracking).
 - **Query:** call `query` → read returned pages → answer with citations →
   optionally file the answer back as a `note`.
+- **CI gate:** run `check` (or `check --json`) → exits non-zero on any hard failure.
+  Add `--error-on-orphan-notes` or `--error-on-untracked-sources` to promote warnings to errors.
 - **Lint:** run `validate` → fix reported issues by issuing further CLI commands.
 - **Drift check:** run `status` → re-ingest stale pages with updated summaries.
 - **Coverage check:** run `coverage` → follow each violation's remedy to ingest missing files

--- a/plugins/ymir/wiki-cli/test/check-cmd.test.ts
+++ b/plugins/ymir/wiki-cli/test/check-cmd.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runCheckCmd } from "../src/commands/check.js";
+import { buildIndex } from "../src/index-build.js";
+import { writePage } from "../src/store.js";
+
+function initProject(): { projectRoot: string; root: string } {
+  const projectRoot = mkdtempSync(join(tmpdir(), "check-cmd-"));
+  const root = join(projectRoot, "wiki");
+  mkdirSync(join(root, "sources"), { recursive: true });
+  mkdirSync(join(root, "notes"), { recursive: true });
+  return { projectRoot, root };
+}
+
+function writeIndex(root: string): void {
+  writePage(join(root, "index.md"), buildIndex(root));
+}
+
+let projectRoot: string;
+let root: string;
+
+beforeEach(() => {
+  ({ projectRoot, root } = initProject());
+});
+
+afterEach(() => {
+  rmSync(projectRoot, { recursive: true, force: true });
+});
+
+describe("runCheckCmd", () => {
+  it("exits 0 and prints 'wiki ok' for a clean wiki", () => {
+    writeIndex(root);
+    const r = runCheckCmd({ root, json: false, errorOnOrphanNotes: false, errorOnUntrackedSources: false });
+    expect(r.exitCode).toBe(0);
+    expect(r.text).toContain("wiki ok");
+  });
+
+  it("exits 1 with human-readable lines for errors", () => {
+    writeFileSync(join(root, "notes", "bad.md"), "---\ntitle: Bad\ntype: nope\n---\n# Bad\n");
+    const r = runCheckCmd({ root, json: false, errorOnOrphanNotes: false, errorOnUntrackedSources: false });
+    expect(r.exitCode).toBe(1);
+    expect(r.text).toContain("error:");
+  });
+
+  it("includes warnings in human output", () => {
+    writeFileSync(
+      join(root, "notes", "alone.md"),
+      "---\ntitle: alone\ntype: concept\ndate: 2026-01-01\ntags: []\nsource_count: 0\n---\n# alone\n",
+    );
+    writeIndex(root);
+    const r = runCheckCmd({ root, json: false, errorOnOrphanNotes: false, errorOnUntrackedSources: false });
+    expect(r.text).toContain("warning:");
+  });
+
+  it("emits valid JSON when --json is set", () => {
+    writeIndex(root);
+    const r = runCheckCmd({ root, json: true, errorOnOrphanNotes: false, errorOnUntrackedSources: false });
+    const parsed = JSON.parse(r.text) as { ok: boolean; errors: unknown[]; warnings: unknown[] };
+    expect(typeof parsed.ok).toBe("boolean");
+    expect(Array.isArray(parsed.errors)).toBe(true);
+    expect(Array.isArray(parsed.warnings)).toBe(true);
+  });
+
+  it("exits 1 when errorOnOrphanNotes is true and orphan exists", () => {
+    writeFileSync(
+      join(root, "notes", "alone.md"),
+      "---\ntitle: alone\ntype: concept\ndate: 2026-01-01\ntags: []\nsource_count: 0\n---\n# alone\n",
+    );
+    writeIndex(root);
+    const r = runCheckCmd({ root, json: false, errorOnOrphanNotes: true, errorOnUntrackedSources: false });
+    expect(r.exitCode).toBe(1);
+  });
+});

--- a/plugins/ymir/wiki-cli/test/check.test.ts
+++ b/plugins/ymir/wiki-cli/test/check.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runCheck } from "../src/check.js";
+import { buildIndex } from "../src/index-build.js";
+import { writePage } from "../src/store.js";
+
+function initProject(): { projectRoot: string; root: string } {
+  const projectRoot = mkdtempSync(join(tmpdir(), "check-"));
+  const root = join(projectRoot, "wiki");
+  mkdirSync(join(root, "sources"), { recursive: true });
+  mkdirSync(join(root, "notes"), { recursive: true });
+  return { projectRoot, root };
+}
+
+function writeSource(root: string, file: string, overrides: Record<string, unknown> = {}): void {
+  const fm = {
+    title: file.replace(/\.md$/, ""),
+    type: "source",
+    date: "2026-01-01",
+    tags: [],
+    source: "raw/stub",
+    ingested: "2026-01-01",
+    ...overrides,
+  };
+  const lines = ["---"];
+  for (const [k, v] of Object.entries(fm)) {
+    if (Array.isArray(v)) {
+      if (v.length === 0) lines.push(`${k}: []`);
+      else lines.push(`${k}:\n${v.map((x) => `  - ${x}`).join("\n")}`);
+    } else {
+      lines.push(`${k}: ${v}`);
+    }
+  }
+  lines.push("---", `# ${fm.title}`, "", "content");
+  writeFileSync(join(root, "sources", file), lines.join("\n") + "\n");
+}
+
+function writeNote(root: string, file: string, body = "", overrides: Record<string, unknown> = {}): void {
+  const title = file.replace(/\.md$/, "");
+  const fm = {
+    title,
+    type: "concept",
+    date: "2026-01-01",
+    tags: [],
+    source_count: 0,
+    ...overrides,
+  };
+  const lines = ["---"];
+  for (const [k, v] of Object.entries(fm)) {
+    if (Array.isArray(v)) {
+      if (v.length === 0) lines.push(`${k}: []`);
+      else lines.push(`${k}:\n${v.map((x) => `  - ${x}`).join("\n")}`);
+    } else {
+      lines.push(`${k}: ${v}`);
+    }
+  }
+  lines.push("---", `# ${title}`, "", body);
+  writeFileSync(join(root, "notes", file), lines.join("\n") + "\n");
+}
+
+function writeIndex(root: string): void {
+  writePage(join(root, "index.md"), buildIndex(root));
+}
+
+let projectRoot: string;
+let root: string;
+
+beforeEach(() => {
+  ({ projectRoot, root } = initProject());
+});
+
+afterEach(() => {
+  rmSync(projectRoot, { recursive: true, force: true });
+});
+
+describe("runCheck", () => {
+  describe("schema and structure", () => {
+    it("passes a valid empty wiki", () => {
+      writeIndex(root);
+      const r = runCheck({ root });
+      expect(r.ok).toBe(true);
+      expect(r.errors).toEqual([]);
+    });
+
+    it("reports schema-invalid error for bad frontmatter", () => {
+      writeFileSync(join(root, "notes", "bad.md"), "---\ntitle: Bad\ntype: nope\n---\n# Bad\n");
+      const r = runCheck({ root });
+      expect(r.ok).toBe(false);
+      expect(r.errors.some((e) => e.kind === "schema-invalid" && e.path?.includes("bad.md"))).toBe(true);
+    });
+
+    it("reports broken-link error", () => {
+      writeNote(root, "a.md", "see [[Ghost]]");
+      const r = runCheck({ root });
+      expect(r.errors.some((e) => e.kind === "broken-link" && e.message.includes("Ghost"))).toBe(true);
+    });
+
+    it("reports slug-collision error", () => {
+      writeSource(root, "hi-u-tr-ng.md", { title: "Hiệu trưởng" });
+      writeNote(root, "hi-u-tr-ng.md", "", { title: "Hiếu trường" });
+      const r = runCheck({ root });
+      expect(r.errors.some((e) => e.kind === "slug-collision")).toBe(true);
+    });
+
+    it("reports filename-mismatch error", () => {
+      writeNote(root, "wrong-name.md", "", { title: "Right Name" });
+      const r = runCheck({ root });
+      expect(r.errors.some((e) => e.kind === "filename-mismatch" && e.path?.includes("wrong-name.md"))).toBe(true);
+    });
+
+    it("reports nested-page error", () => {
+      mkdirSync(join(root, "notes", "sub"), { recursive: true });
+      writeFileSync(join(root, "notes", "sub", "deep.md"), "---\ntitle: Deep\ntype: concept\ndate: 2026-01-01\ntags: []\nsource_count: 0\n---\n# Deep\n");
+      const r = runCheck({ root });
+      expect(r.errors.some((e) => e.kind === "nested-page")).toBe(true);
+    });
+  });
+
+  describe("orphan notes", () => {
+    it("warns on orphan note by default", () => {
+      writeNote(root, "alone.md");
+      writeIndex(root);
+      const r = runCheck({ root });
+      expect(r.warnings.some((w) => w.kind === "orphan-note" && w.path?.includes("alone.md"))).toBe(true);
+      expect(r.ok).toBe(true);
+    });
+
+    it("errors on orphan note when errorOnOrphanNotes is true", () => {
+      writeNote(root, "alone.md");
+      writeIndex(root);
+      const r = runCheck({ root, errorOnOrphanNotes: true });
+      expect(r.errors.some((e) => e.kind === "orphan-note")).toBe(true);
+      expect(r.ok).toBe(false);
+    });
+  });
+
+  describe("provenance drift", () => {
+    it("reports stale-source error when source hash changed", () => {
+      writeFileSync(join(projectRoot, "src.ts"), "original content");
+      writeSource(root, "my-source.md", {
+        title: "My Source",
+        source_path: "src.ts",
+        source_hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      });
+
+      const r = runCheck({ root });
+      expect(r.errors.some((e) => e.kind === "stale-source")).toBe(true);
+      expect(r.ok).toBe(false);
+    });
+
+    it("reports missing-source error when source file not found", () => {
+      writeSource(root, "my-source.md", {
+        title: "My Source",
+        source_path: "nonexistent.ts",
+        source_hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      });
+
+      const r = runCheck({ root });
+      expect(r.errors.some((e) => e.kind === "missing-source")).toBe(true);
+      expect(r.ok).toBe(false);
+    });
+
+    it("warns on untracked-source by default", () => {
+      writeSource(root, "my-source.md", { title: "My Source" });
+      writeIndex(root);
+      const r = runCheck({ root });
+      expect(r.warnings.some((w) => w.kind === "untracked-source")).toBe(true);
+      expect(r.ok).toBe(true);
+    });
+
+    it("errors on untracked-source when errorOnUntrackedSources is true", () => {
+      writeSource(root, "my-source.md", { title: "My Source" });
+      writeIndex(root);
+      const r = runCheck({ root, errorOnUntrackedSources: true });
+      expect(r.errors.some((e) => e.kind === "untracked-source")).toBe(true);
+      expect(r.ok).toBe(false);
+    });
+  });
+
+  describe("index freshness", () => {
+    it("passes when index is up to date", () => {
+      writeSource(root, "my-source.md", { title: "My Source" });
+      writeIndex(root);
+      const r = runCheck({ root });
+      expect(r.errors.some((e) => e.kind === "stale-index")).toBe(false);
+    });
+
+    it("reports stale-index error when index.md is missing", () => {
+      writeSource(root, "my-source.md", { title: "My Source" });
+      const r = runCheck({ root });
+      expect(r.errors.some((e) => e.kind === "stale-index")).toBe(true);
+      expect(r.ok).toBe(false);
+    });
+
+    it("reports stale-index error when index.md content is outdated", () => {
+      writeSource(root, "my-source.md", { title: "My Source" });
+      writePage(join(root, "index.md"), "# Wiki Index\n\n## Sources\n\n_none yet_\n\n## Notes\n\n_none yet_\n");
+      const r = runCheck({ root });
+      expect(r.errors.some((e) => e.kind === "stale-index")).toBe(true);
+    });
+  });
+
+  describe("coverage", () => {
+    it("passes when no tracked.yaml exists", () => {
+      writeIndex(root);
+      const r = runCheck({ root });
+      expect(r.errors.some((e) => e.kind?.startsWith("coverage-"))).toBe(false);
+    });
+
+    it("reports coverage-uncovered when file lacks a source page", () => {
+      mkdirSync(join(projectRoot, "src"), { recursive: true });
+      writeFileSync(join(projectRoot, "src", "auth.ts"), "content");
+      writeFileSync(join(root, "tracked.yaml"), 'include:\n  - "src/**/*.ts"\n');
+
+      const r = runCheck({ root });
+      expect(r.errors.some((e) => e.kind === "coverage-uncovered" && e.path?.includes("auth.ts"))).toBe(true);
+      expect(r.ok).toBe(false);
+    });
+  });
+
+  describe("JSON output schema", () => {
+    it("returns stable CheckReport shape with ok, errors, warnings", () => {
+      writeIndex(root);
+      const r = runCheck({ root });
+      expect(typeof r.ok).toBe("boolean");
+      expect(Array.isArray(r.errors)).toBe(true);
+      expect(Array.isArray(r.warnings)).toBe(true);
+    });
+
+    it("every finding has kind and message", () => {
+      writeNote(root, "alone.md");
+      writeIndex(root);
+      const r = runCheck({ root });
+      for (const f of [...r.errors, ...r.warnings]) {
+        expect(typeof f.kind).toBe("string");
+        expect(typeof f.message).toBe("string");
+      }
+    });
+  });
+});

--- a/wiki/SCHEMA.md
+++ b/wiki/SCHEMA.md
@@ -25,6 +25,13 @@ Run `... help` for the full command reference. Key commands:
   Use `--raw <label>` (legacy) when ingesting from a non-tracked input.
 - `note --type entity|concept|topic --name <n>` (body on STDIN) — synthesis page.
 - `index` — rebuild the catalog.
+- `check [--json] [--error-on-orphan-notes] [--error-on-untracked-sources]` — single CI gate.
+  Evaluates schema validity, page identity, broken links, orphan policy, provenance drift,
+  untracked sources, declarative coverage, and index freshness in one read-only pass.
+  Exits non-zero on any hard failure; zero only when the wiki satisfies policy.
+  Orphan notes and untracked sources are warnings by default; promote to errors with the
+  respective flags. Use `--json` for machine-readable output with stable schema
+  `{ ok, errors[], warnings[] }`, each finding carrying `kind`, `message`, and `remedy`.
 - `validate` — health check (frontmatter, `[[links]]`, orphans, slug collisions, filename/title mismatches, nested pages).
 - `status` — show drift between source pages and their tracked files.
   Use `--json` for machine-readable output (exit 1 if stale/missing).
@@ -53,6 +60,8 @@ Run `... help` for the full command reference. Key commands:
   `ingest --raw <raw/path> --title <t>` (no drift tracking).
 - **Query:** call `query` → read returned pages → answer with citations →
   optionally file the answer back as a `note`.
+- **CI gate:** run `check` (or `check --json`) → exits non-zero on any hard failure.
+  Add `--error-on-orphan-notes` or `--error-on-untracked-sources` to promote warnings to errors.
 - **Lint:** run `validate` → fix reported issues by issuing further CLI commands.
 - **Drift check:** run `status` → re-ingest stale pages with updated summaries.
 - **Coverage check:** run `coverage` → follow each violation's remedy to ingest missing files


### PR DESCRIPTION
## Summary

- Adds `wiki check` command that combines validate, status, coverage, and index freshness into one read-only pass
- Exits non-zero on any hard failure; zero only when the wiki satisfies policy
- Orphan notes and untracked sources are warnings by default; `--error-on-orphan-notes` and `--error-on-untracked-sources` promote them to hard errors
- `--json` emits stable `{ ok, errors[], warnings[] }` schema with `kind`, `message`, and `remedy` on each finding
- 24 new tests covering all failure classes; 208 total passing

## Test plan

- [x] `bun test` — 208 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] All check kinds tested: schema-invalid, nested-page, filename-mismatch, slug-collision, broken-link, orphan-note (warn/error), stale-source, missing-source, untracked-source (warn/error), coverage-uncovered, stale-index
- [x] JSON output schema verified
- [x] SCHEMA.md template and wiki/SCHEMA.md updated to document the new command

Fixes #26