### PR TITLE
fix(wiki-cli): correct help text and add --raw warning for project files

### DIFF
--- a/plugins/ymir/wiki-cli/src/cli.ts
+++ b/plugins/ymir/wiki-cli/src/cli.ts
@@ -58,6 +58,14 @@ program
       ingestSourceHash = prov.sourceHash;
     } else {
       raw = opts.raw!;
+      const absRaw = resolve(opts.raw!);
+      const rawDir = resolve(root, "raw");
+      if (existsSync(absRaw) && !absRaw.startsWith(rawDir + "/") && absRaw !== rawDir) {
+        process.stderr.write(
+          `warning: "${opts.raw}" exists in the project; the resulting page will be untracked.\n` +
+          `  Use --source instead to record provenance and enable drift detection.\n`,
+        );
+      }
     }
 
     const path = await runIngest({

--- a/plugins/ymir/wiki-cli/src/commands/help.ts
+++ b/plugins/ymir/wiki-cli/src/commands/help.ts
@@ -4,13 +4,30 @@ You must NOT hand-write or hand-edit files under wiki/sources, wiki/notes,
 index.md, or log.md. Use these commands; they format + validate every write.
 
 Commands:
-  ingest --raw <path> --title <t>     Ingest a source from wiki/raw into a summary page.
+  init [--project-root <dir>] [--name <n>]
+                                      Scaffold a wiki in the project: creates wiki/ dirs,
+                                      SCHEMA.md, index.md, log.md, a block-wiki-edits hook,
+                                      and merges .claude/settings.json. Safe to re-run.
+  ingest --source <path> --title <t>  Ingest a project file into a tracked source page.
+                                      Records source_path + source_hash for drift detection.
+                                      Body is read from STDIN.
+  ingest --raw <label> --title <t>    Ingest external material (e.g. wiki/raw/paper.pdf).
+                                      No provenance hash — page is untracked by status.
+                                      Use --source instead for any file that lives in the repo.
                                       Body is read from STDIN.
   note --type <entity|concept|topic> --name <n>
                                       Create/update a synthesis note. Body from STDIN.
+  status [--json]                     Show drift between source pages and their tracked files.
+                                      States: current (hash matches), stale (file changed),
+                                      missing (file deleted), untracked (no source_hash).
+                                      Exit 1 if any page is stale or missing.
   index                               Rebuild index.md from all pages.
   log <op> <title>                    Append a dated entry to log.md.
-  remove --title <t> [--preview]       Delete a source or note and rebuild all generated state.
+  check [--json] [--error-on-orphan-notes] [--error-on-untracked-sources]
+                                      Single CI gate: validates schema, links, orphans,
+                                      provenance drift, coverage, and index freshness.
+                                      Exit !=0 on any hard failure.
+  remove --title <t> [--preview]      Delete a source or note and rebuild all generated state.
                                       Refuses if inbound [[links]] exist — fix those first.
                                       --preview: report impact without writing.
   rename --old-title <t> --new-title <t> [--preview]
@@ -32,13 +49,16 @@ Commands:
   help                                Show this text.
 
 Page conventions:
-  Source page frontmatter: title, type=source, date, tags[], source, ingested
+  Source page frontmatter: title, type=source, date, tags[], source_path, source_hash, ingested
   Note page frontmatter:   title, type=entity|concept|topic, date, tags[], source_count
   Cross-reference other pages with [[Exact Title]].
 
 Examples:
-  echo "Key points..." | wiki ingest --raw raw/paper.pdf --title "Rate Limiting"
+  wiki init
+  echo "Key points..." | wiki ingest --source src/auth.ts --title "Auth Module"
+  echo "External notes..." | wiki ingest --raw raw/paper.pdf --title "Rate Limiting"
   echo "A token-bucket limiter. See [[Rate Limiting]]." | wiki note --type concept --name "Token Bucket"
+  wiki status
   wiki query "how does backoff work"
   wiki query "backoff" --limit 20 --chunks
   wiki validate

--- a/plugins/ymir/wiki-cli/test/help.test.ts
+++ b/plugins/ymir/wiki-cli/test/help.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "bun:test";
+import { HELP_TEXT } from "../src/commands/help.js";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const schemaTemplate = readFileSync(
+  join(import.meta.dir, "../src/templates/wiki/SCHEMA.md"),
+  "utf8",
+);
+
+describe("HELP_TEXT contract", () => {
+  it("documents --source as the tracked ingest path", () => {
+    expect(HELP_TEXT).toContain("--source");
+  });
+
+  it("documents the init command", () => {
+    expect(HELP_TEXT).toContain("init");
+  });
+
+  it("documents the status command", () => {
+    expect(HELP_TEXT).toContain("status");
+  });
+
+  it("lists all four status states", () => {
+    expect(HELP_TEXT).toContain("current");
+    expect(HELP_TEXT).toContain("stale");
+    expect(HELP_TEXT).toContain("missing");
+    expect(HELP_TEXT).toContain("untracked");
+  });
+
+  it("documents source_path and source_hash in page conventions", () => {
+    expect(HELP_TEXT).toContain("source_path");
+    expect(HELP_TEXT).toContain("source_hash");
+  });
+
+  it("describes --raw as the external/legacy path, not the default", () => {
+    const sourceIndex = HELP_TEXT.indexOf("--source");
+    const rawIndex = HELP_TEXT.indexOf("--raw");
+    expect(sourceIndex).toBeGreaterThan(-1);
+    expect(rawIndex).toBeGreaterThan(-1);
+    expect(sourceIndex).toBeLessThan(rawIndex);
+  });
+});
+
+describe("SCHEMA.md scaffold template contract", () => {
+  it("mentions --source as the tracked ingest path", () => {
+    expect(schemaTemplate).toContain("--source");
+  });
+
+  it("mentions status command", () => {
+    expect(schemaTemplate).toContain("status");
+  });
+
+  it("mentions source_path and source_hash provenance keys", () => {
+    expect(schemaTemplate).toContain("source_path");
+    expect(schemaTemplate).toContain("source_hash");
+  });
+});


### PR DESCRIPTION
## Summary

- Updates `HELP_TEXT` in `src/commands/help.ts` to document `init`, `status` (with all four states: `current`, `stale`, `missing`, `untracked`), and `ingest --source` as the primary tracked path; `--raw` is now described as the external/legacy-only path
- Fixes source page frontmatter docs to list `source_path` and `source_hash` instead of the old `source, ingested`
- Emits a `stderr` warning when `--raw` is used with an existing project-internal file, pointing the user to `--source`
- Adds `test/help.test.ts` to lock the `HELP_TEXT` contract and scaffold template so this cannot silently drift again

## Test plan

- [x] `bun test` — 223 pass, 0 fail (214 existing + 9 new)
- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean

Fixes #30