### PR TITLE
feat(ci): gate Ymir's own wiki health in CI and wire local drift hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,23 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CLAUDE_PLUGIN_ROOT=\"${CLAUDE_PROJECT_DIR}/plugins/ymir\" node \"${CLAUDE_PROJECT_DIR}/plugins/ymir/hooks/ensure-wiki-binary.mjs\"",
+            "timeout": 120
+          },
+          {
+            "type": "command",
+            "command": "CLAUDE_PLUGIN_ROOT=\"${CLAUDE_PROJECT_DIR}/plugins/ymir\" node \"${CLAUDE_PROJECT_DIR}/plugins/ymir/hooks/wiki-sync-status.mjs\"",
+            "timeout": 30
+          }
+        ]
+      }
     ]
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,16 @@ jobs:
         run: bun test
       - name: Build
         run: bun run build
+
+  wiki-health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install released wiki binary
+        run: |
+          gh release download --pattern 'wiki-linux-x64' --dir /tmp/wiki-bin
+          install -m 755 /tmp/wiki-bin/wiki-linux-x64 /usr/local/bin/wiki
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Wiki health check
+        run: wiki --root wiki check --error-on-untracked-sources


### PR DESCRIPTION
Closes #32.

## Summary

- Adds a `wiki-health` job to CI that downloads the **released** `wiki-linux-x64` binary and runs `wiki check --error-on-untracked-sources` against `wiki/`. This exercises the consumer's binary experience rather than in-repo source paths.
- The job fails on any stale, missing, or untracked source page; validation errors; a stale `index.md`; and coverage violations when a coverage policy exists.
- Wires both `ensure-wiki-binary.mjs` (downloads binary on session start) and `wiki-sync-status.mjs` (surfaces drift) as SessionStart hooks in `.claude/settings.json`, with `CLAUDE_PLUGIN_ROOT` pointing to `plugins/ymir` so contributors get local feedback without a marketplace install.

## Test plan

- [ ] CI `wiki-health` job appears in the Actions run for this PR
- [ ] Job downloads the binary, runs `wiki check --error-on-untracked-sources`, and exits 0
- [ ] Starting a new Claude Code session on this repo triggers the SessionStart hooks (binary download + drift check)
- [ ] `wiki check --error-on-untracked-sources` passes locally (confirmed: `wiki ok`)
- [ ] All 225 existing tests still pass (confirmed)