### PR TITLE
feat(skills): replace CLAUDE_PLUGIN_ROOT with skill-root-relative paths and self-provisioning

### DIFF
--- a/plugins/ymir/SKILL.md
+++ b/plugins/ymir/SKILL.md
@@ -54,10 +54,19 @@ If — and only if — the intent is explicitly to create the wiki
 (`ymir add context`, `ymir add wiki`), Ymir **executes** the wiki scaffold
 immediately against the project via **a single CLI call** — never by hand-editing
 files. The CLI owns the tree, the PreToolUse hook, the `.claude/settings.json`
-entry, the `CLAUDE.md` block, and the validation step. From the project root:
+entry, the `CLAUDE.md` block, and the validation step.
+
+All asset paths below (`references/`, `templates/`, `wiki-cli/`, `hooks/`) are
+**relative to this skill's root directory** — the directory that contains this
+`SKILL.md`. Resolve `$SKILL_ROOT` as that directory before running any command
+(`CLAUDE_PLUGIN_ROOT` holds it in Claude Code plugin installs; derive it from this
+file's path for skills-CLI installs).
+
+Provision the wiki binary once (idempotent), then scaffold from the project root:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/wiki-cli/bin/wiki" --root ./wiki init
+node "$SKILL_ROOT/hooks/ensure-wiki-binary.mjs"
+"$SKILL_ROOT/wiki-cli/bin/wiki" --root ./wiki init
 ```
 
 It is idempotent (safe to re-run); on success the last line is `wiki valid`. If it
@@ -109,7 +118,7 @@ in-scope concern. For each concern run the 4-move engine — **probe why → rec
 (2-3 trade-offs, recommendation first) → adaptive follow-up only when needed →
 confirm** — asking **one question per `AskUserQuestion` message**. The full engine,
 the per-concern probe bank, the rules scope-probing, and the greenfield phrasing
-live in `${CLAUDE_PLUGIN_ROOT}/references/socratic-interview.md` — read it before
+live in `references/socratic-interview.md` (relative to the skill root) — read it before
 interviewing.
 
 - For `ymir init`, sweep the whole checklist; for a narrow action (e.g. `add
@@ -117,7 +126,7 @@ interviewing.
 - The user may skip a concern → record `status: skipped` with a `reason`.
 - Write each answer into `.ymir/harness-profile.yaml` as you go, including
   `why`, `findings`, and `alternatives_considered`. Field shape:
-  `${CLAUDE_PLUGIN_ROOT}/templates/harness-profile.schema.md`.
+  `templates/harness-profile.schema.md` (relative to the skill root).
 
 ## Step 2 — Consistency + re-audit (gate)
 
@@ -143,9 +152,9 @@ Assemble the playbook from the bundled per-concern templates — do not free-for
 1. Ensure `.ymir/harness-profile.yaml` reflects the final audited decisions
    (`spec_version: 2`).
 2. Write `.ymir/harness-playbook.md`: start from
-   `${CLAUDE_PLUGIN_ROOT}/templates/playbook/header.md` (fill `{{PROJECT}}` and
+   `templates/playbook/header.md` (fill `{{PROJECT}}` and
    `{{DATE}}`), then append one section per `captured` concern from
-   `${CLAUDE_PLUGIN_ROOT}/templates/playbook/<concern>.md`, filling every `{{...}}`
+   `templates/playbook/<concern>.md`, filling every `{{...}}`
    placeholder (including the `Why / Findings` block) from the profile. Omit
    `skipped` concerns.
 3. Tell the user the spec is ready under `.ymir/`.

--- a/plugins/ymir/hooks/ensure-wiki-binary.mjs
+++ b/plugins/ymir/hooks/ensure-wiki-binary.mjs
@@ -4,7 +4,8 @@ import {
   chmodSync, existsSync, mkdirSync,
   readFileSync, renameSync, unlinkSync, writeFileSync,
 } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { createHash } from "node:crypto";
 
 // Keep in sync with wiki-cli/src/platform.ts (cannot import TS from this .mjs hook).
@@ -17,16 +18,13 @@ function detectAssetLabel(unameSM) {
   throw new Error(`Unsupported platform: "${s}". Supported: Darwin/Linux × arm64/x86_64.`);
 }
 
-const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT;
-if (!PLUGIN_ROOT) {
-  process.stderr.write("[ymir] CLAUDE_PLUGIN_ROOT not set — cannot ensure wiki binary\n");
-  process.exit(2);
-}
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const SKILL_ROOT = process.env.CLAUDE_PLUGIN_ROOT ?? join(SCRIPT_DIR, "..");
 
 let pluginVersion;
 try {
   const manifest = JSON.parse(
-    readFileSync(join(PLUGIN_ROOT, ".claude-plugin/plugin.json"), "utf8")
+    readFileSync(join(SKILL_ROOT, ".claude-plugin/plugin.json"), "utf8")
   );
   pluginVersion = manifest.version;
 } catch (e) {
@@ -39,16 +37,14 @@ if (typeof pluginVersion !== "string" || !/^\d+\.\d+\.\d+/.test(pluginVersion)) 
   process.exit(2);
 }
 
-const binDir    = join(PLUGIN_ROOT, "wiki-cli/bin");
+const binDir    = join(SKILL_ROOT, "wiki-cli/bin");
 const binPath   = join(binDir, "wiki");
 const stampPath = join(binDir, ".version");
 
-// Fast path: already installed and version matches
 if (existsSync(binPath) && existsSync(stampPath)) {
   if (readFileSync(stampPath, "utf8").trim() === pluginVersion) process.exit(0);
 }
 
-// Detect platform
 let label;
 try {
   const uname = execSync("uname -sm", { encoding: "utf8" });
@@ -72,7 +68,6 @@ const cleanupTmp = () => {
   try { unlinkSync(tmpSums); } catch {}
 };
 
-// Download binary
 const dlBin = spawnSync("curl", ["-fsSL", "--output", tmpBin, assetUrl], { stdio: "inherit" });
 if (dlBin.status !== 0) {
   cleanupTmp();
@@ -80,7 +75,6 @@ if (dlBin.status !== 0) {
   process.exit(2);
 }
 
-// Download checksum file
 const dlSums = spawnSync("curl", ["-fsSL", "--output", tmpSums, sumsUrl], { stdio: "inherit" });
 if (dlSums.status !== 0) {
   cleanupTmp();
@@ -88,7 +82,6 @@ if (dlSums.status !== 0) {
   process.exit(2);
 }
 
-// Verify sha256
 const sumsText     = readFileSync(tmpSums, "utf8");
 const expectedLine = sumsText.split("\n").find((l) => {
   const name = l.trim().split(/\s+/)[1];
@@ -109,7 +102,6 @@ if (actualHash !== expectedHash) {
   process.exit(2);
 }
 
-// Install
 renameSync(tmpBin, binPath);
 chmodSync(binPath, 0o755);
 writeFileSync(stampPath, pluginVersion);

--- a/plugins/ymir/hooks/wiki-sync-status.mjs
+++ b/plugins/ymir/hooks/wiki-sync-status.mjs
@@ -1,17 +1,18 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT;
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const SKILL_ROOT = process.env.CLAUDE_PLUGIN_ROOT ?? join(SCRIPT_DIR, "..");
 const wikiRoot = "./wiki";
 
-// If wiki dir or binary absent → silent exit
-if (!existsSync(wikiRoot) || !PLUGIN_ROOT) {
+if (!existsSync(wikiRoot)) {
   process.exit(0);
 }
 
-const wikiBin = join(PLUGIN_ROOT, "wiki-cli/bin/wiki");
+const wikiBin = join(SKILL_ROOT, "wiki-cli/bin/wiki");
 if (!existsSync(wikiBin)) {
   process.exit(0);
 }
@@ -42,7 +43,7 @@ try {
 
   process.stdout.write(formatSyncMessage(stale, missing, wikiRoot));
 } catch {
-  // Never block session
+  // never block session start
 }
 
 process.exit(0);

--- a/plugins/ymir/templates/playbook/wiki.md
+++ b/plugins/ymir/templates/playbook/wiki.md
@@ -9,12 +9,15 @@ harness is scaffolded by **a single CLI call** — never by hand-editing files. 
 CLI owns the tree, the PreToolUse hook, the `.claude/settings.json` entry, the
 `CLAUDE.md` block, and the validation step.
 
-1. **Scaffold + verify** — from the project root, run:
+1. **Scaffold + verify** — provision the wiki binary (idempotent), then from the
+   project root run:
 
    ```bash
-   "${CLAUDE_PLUGIN_ROOT}/wiki-cli/bin/wiki" --root ./wiki init
+   node "$SKILL_ROOT/hooks/ensure-wiki-binary.mjs"
+   "$SKILL_ROOT/wiki-cli/bin/wiki" --root ./wiki init
    ```
 
+   `$SKILL_ROOT` is the Ymir skill's root directory (contains `SKILL.md`).
    It is idempotent (safe to re-run). On success the last line is `wiki valid`.
    If it errors, stop and report.
 
@@ -23,5 +26,5 @@ CLI owns the tree, the PreToolUse hook, the `.claude/settings.json` entry, the
    (BM25) — no `qmd embed`; re-run `qmd collection add` to refresh after adding
    pages.
 
-- **Verify:** `"${CLAUDE_PLUGIN_ROOT}/wiki-cli/bin/wiki" --root ./wiki validate`
+- **Verify:** `"$SKILL_ROOT/wiki-cli/bin/wiki" --root ./wiki validate`
   prints `wiki valid`.

--- a/plugins/ymir/wiki-cli/src/commands/init.ts
+++ b/plugins/ymir/wiki-cli/src/commands/init.ts
@@ -1,5 +1,5 @@
 import {
-  existsSync, mkdirSync, readFileSync, writeFileSync,
+  existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync,
 } from "node:fs";
 import { dirname, join, basename, resolve } from "node:path";
 import { validateWiki } from "../validate.js";
@@ -23,10 +23,13 @@ export function runInit(opts: {
   projectRoot: string;
   root: string;
   name?: string;
+  wikiBin?: string;
 }): InitSummary {
   const projectRoot = resolve(opts.projectRoot);
   const wikiRoot = resolve(projectRoot, opts.root);
   const name = opts.name ?? basename(projectRoot);
+  const rawBin = process.argv[0];
+  const wikiBin = opts.wikiBin ?? (rawBin !== undefined ? realpathSync(rawBin) : "wiki");
 
   const created: string[] = [];
   const skipped: string[] = [];
@@ -43,7 +46,7 @@ export function runInit(opts: {
   }
   writeIfMissing(
     join(wikiRoot, "SCHEMA.md"),
-    SCHEMA_TPL.replaceAll("PROJECT_NAME", name),
+    SCHEMA_TPL.replaceAll("PROJECT_NAME", name).replaceAll("{{WIKI_BIN}}", wikiBin),
   );
   writeIfMissing(join(wikiRoot, "index.md"), INDEX_SEED);
   writeIfMissing(join(wikiRoot, "log.md"), LOG_SEED);

--- a/plugins/ymir/wiki-cli/src/templates/wiki/SCHEMA.md
+++ b/plugins/ymir/wiki-cli/src/templates/wiki/SCHEMA.md
@@ -16,7 +16,7 @@ formats and validates every change. Direct edits to `sources/`, `notes/`,
 Invoke via the bundled binary:
 
 ```
-${CLAUDE_PLUGIN_ROOT}/wiki-cli/bin/wiki --root ./wiki <command>
+{{WIKI_BIN}} --root ./wiki <command>
 ```
 
 Run `... help` for the full command reference. Key commands:

--- a/plugins/ymir/wiki-cli/test/init.test.ts
+++ b/plugins/ymir/wiki-cli/test/init.test.ts
@@ -19,6 +19,7 @@ describe("runInit", () => {
     }
     const schema = readFileSync(join(wiki, "SCHEMA.md"), "utf8");
     expect(schema).not.toContain("PROJECT_NAME");
+    expect(schema).not.toContain("{{WIKI_BIN}}");
     expect(schema).toContain(basename(proj));
 
     expect(existsSync(join(proj, ".claude/hooks/block-wiki-edits.mjs"))).toBe(true);

--- a/plugins/ymir/wiki-cli/test/path-portability.test.ts
+++ b/plugins/ymir/wiki-cli/test/path-portability.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { readFileSync, existsSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runInit } from "../src/commands/init.js";
+
+const skillRoot = join(import.meta.dir, "../..");
+const hooksDir = join(skillRoot, "hooks");
+const templatesDir = join(skillRoot, "templates");
+const wikiCliTemplatesDir = join(skillRoot, "wiki-cli/src/templates");
+
+function readText(path: string): string {
+  return readFileSync(path, "utf-8");
+}
+
+function occurrences(text: string, needle: string): number {
+  return (text.match(new RegExp(needle.replace(/[${}]/g, "\\$&"), "g")) ?? []).length;
+}
+
+describe("CLAUDE_PLUGIN_ROOT absent from skill body", () => {
+  test("SKILL.md has zero CLAUDE_PLUGIN_ROOT occurrences", () => {
+    const text = readText(join(skillRoot, "SKILL.md"));
+    expect(occurrences(text, "${CLAUDE_PLUGIN_ROOT}")).toBe(0);
+  });
+
+  test("templates/playbook/wiki.md has zero CLAUDE_PLUGIN_ROOT occurrences", () => {
+    const text = readText(join(templatesDir, "playbook/wiki.md"));
+    expect(occurrences(text, "${CLAUDE_PLUGIN_ROOT}")).toBe(0);
+  });
+
+  test("wiki-cli SCHEMA.md template has zero CLAUDE_PLUGIN_ROOT occurrences", () => {
+    const text = readText(join(wikiCliTemplatesDir, "wiki/SCHEMA.md"));
+    expect(occurrences(text, "${CLAUDE_PLUGIN_ROOT}")).toBe(0);
+  });
+});
+
+describe("ensure-wiki-binary.mjs self-location", () => {
+  const scriptPath = join(hooksDir, "ensure-wiki-binary.mjs");
+
+  test("script file exists", () => {
+    expect(existsSync(scriptPath)).toBe(true);
+  });
+
+  test("script uses import.meta.url for self-location (not just CLAUDE_PLUGIN_ROOT)", () => {
+    const text = readText(scriptPath);
+    expect(text).toContain("import.meta.url");
+  });
+
+  test("script does not unconditionally exit(2) on missing CLAUDE_PLUGIN_ROOT", () => {
+    const text = readText(scriptPath);
+    const hasUnconditionalExit =
+      /if\s*\(!PLUGIN_ROOT\)[\s\S]*?process\.exit\(2\)/m.test(text) &&
+      !text.includes("import.meta.url");
+    expect(hasUnconditionalExit).toBe(false);
+  });
+});
+
+describe("wiki-sync-status.mjs self-location", () => {
+  const scriptPath = join(hooksDir, "wiki-sync-status.mjs");
+
+  test("script uses import.meta.url or works when CLAUDE_PLUGIN_ROOT is absent", () => {
+    const text = readText(scriptPath);
+    const hasImportMeta = text.includes("import.meta.url");
+    const gracefulAbsence = /if\s*\(.*!PLUGIN_ROOT.*\)[\s\S]*?process\.exit\(0\)/.test(text);
+    expect(hasImportMeta || gracefulAbsence).toBe(true);
+  });
+});
+
+describe("runInit emits the concrete wiki binary path into SCHEMA.md", () => {
+  let proj: string;
+  beforeEach(() => { proj = mkdtempSync(join(tmpdir(), "schema-bin-")); });
+
+  test("SCHEMA.md has no {{WIKI_BIN}} placeholder — it is replaced at scaffold time", () => {
+    runInit({ projectRoot: proj, root: "wiki", wikiBin: "/usr/local/bin/wiki" });
+    const schema = readFileSync(join(proj, "wiki/SCHEMA.md"), "utf-8");
+    expect(schema).not.toContain("{{WIKI_BIN}}");
+  });
+
+  test("SCHEMA.md contains the injected binary path", () => {
+    runInit({ projectRoot: proj, root: "wiki", wikiBin: "/opt/tools/wiki" });
+    const schema = readFileSync(join(proj, "wiki/SCHEMA.md"), "utf-8");
+    expect(schema).toContain("/opt/tools/wiki");
+  });
+
+  test("SCHEMA.md has no CLAUDE_PLUGIN_ROOT in emitted output", () => {
+    runInit({ projectRoot: proj, root: "wiki", wikiBin: "/usr/local/bin/wiki" });
+    const schema = readFileSync(join(proj, "wiki/SCHEMA.md"), "utf-8");
+    expect(occurrences(schema, "${CLAUDE_PLUGIN_ROOT}")).toBe(0);
+  });
+});

--- a/wiki/SCHEMA.md
+++ b/wiki/SCHEMA.md
@@ -13,10 +13,11 @@ formats and validates every change. Direct edits to `sources/`, `notes/`,
 - `log.md` — CLI-appended timeline. Never edit by hand.
 
 ## The CLI
-Invoke via the bundled binary:
+Invoke via the bundled binary (`$SKILL_ROOT` is the Ymir skill root — the
+directory containing `SKILL.md`):
 
 ```
-${CLAUDE_PLUGIN_ROOT}/wiki-cli/bin/wiki --root ./wiki <command>
+$SKILL_ROOT/wiki-cli/bin/wiki --root ./wiki <command>
 ```
 
 Run `... help` for the full command reference. Key commands:

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -56,3 +56,9 @@
 ## [2026-08-18] note | Socratic Interview Flow
 ## [2026-08-18] note | Harness Playbook Model
 ## [2026-08-18] note | Wiki Harness Model
+## [2026-08-18] ingest | Wiki Schema
+## [2026-08-18] ingest | Playbook Wiki
+## [2026-08-18] ingest | Ymir SKILL Dispatcher
+## [2026-08-18] ingest | Ymir SKILL Dispatcher
+## [2026-08-18] ingest | Playbook Wiki
+## [2026-08-18] ingest | Wiki Schema

--- a/wiki/sources/playbook-wiki.md
+++ b/wiki/sources/playbook-wiki.md
@@ -5,10 +5,39 @@ date: 2026-08-18
 tags: []
 source: plugins/ymir/templates/playbook/wiki.md
 source_path: plugins/ymir/templates/playbook/wiki.md
-source_hash: e38c30a587bf0339f815ec88d205cd62211d6b89f83956e6b7474125fce029c1
+source_hash: 5b58433103b94f96eda6d43a5b8e08b269010228637fc718d6369547d03514bd
 ingested: 2026-08-18
 ---
 
 # Playbook Wiki
 
-Playbook section template for the wiki/context concern. Opens with a Why/Findings placeholder block, targets the wiki/ tree plus .claude/hooks/block-wiki-edits.mjs, and takes concerns.wiki.enabled/collection and meta.project as Inputs. Its single Step runs the idempotent wiki init CLI call (the CLI owns the tree, PreToolUse hook, settings.json entry, CLAUDE.md block, and validation), then tells the user the one-time qmd collection add setup for BM25 keyword search (no qmd embed). Verify requires wiki --root ./wiki validate to print "wiki valid".
+## wiki / context → LLM-maintained wiki
+
+* **Why / Findings:** {{WIKI\_WHY}} — repo scan: {{WIKI\_FINDINGS}}.
+* **Target:** the `wiki/` tree + `.claude/hooks/block-wiki-edits.mjs`
+* **Inputs:** `concerns.wiki.enabled` (run only when `true`), `concerns.wiki.collection`, `meta.project`
+
+This lays down an LLM-maintained wiki backed by the Ymir wiki CLI. The wiki
+harness is scaffolded by **a single CLI call** — never by hand-editing files. The
+CLI owns the tree, the PreToolUse hook, the `.claude/settings.json` entry, the
+`CLAUDE.md` block, and the validation step.
+
+1. **Scaffold + verify** — provision the wiki binary (idempotent), then from the
+   project root run:
+
+   ```bash
+   node "$SKILL_ROOT/hooks/ensure-wiki-binary.mjs"
+   "$SKILL_ROOT/wiki-cli/bin/wiki" --root ./wiki init
+   ```
+
+   `$SKILL_ROOT` is the Ymir skill's root directory (contains `SKILL.md`).
+   It is idempotent (safe to re-run). On success the last line is `wiki valid`.
+   If it errors, stop and report.
+
+2. **Tell the user** the qmd one-time setup (also in `wiki/SCHEMA.md`):
+   `qmd collection add ./wiki --name <project>-wiki`. Search is keyword-only
+   (BM25) — no `qmd embed`; re-run `qmd collection add` to refresh after adding
+   pages.
+
+* **Verify:** `"$SKILL_ROOT/wiki-cli/bin/wiki" --root ./wiki validate`
+  prints `wiki valid`.

--- a/wiki/sources/wiki-schema.md
+++ b/wiki/sources/wiki-schema.md
@@ -5,7 +5,7 @@ date: 2026-08-18
 tags: []
 source: wiki/SCHEMA.md
 source_path: wiki/SCHEMA.md
-source_hash: eed87e045d4e5df7b17b60cdf9ccff2c7c37be058a85c9a41524f2c2aa9ccf21
+source_hash: 8a446f542eb3038bf86ba07ce2a3ab9839c8254f760e9312091b0742a2cb462a
 ingested: 2026-08-18
 ---
 
@@ -28,10 +28,11 @@ formats and validates every change. Direct edits to `sources/`, `notes/`,
 
 ## The CLI
 
-Invoke via the bundled binary:
+Invoke via the bundled binary (`$SKILL_ROOT` is the Ymir skill root — the
+directory containing `SKILL.md`):
 
 ```
-${CLAUDE_PLUGIN_ROOT}/wiki-cli/bin/wiki --root ./wiki <command>
+$SKILL_ROOT/wiki-cli/bin/wiki --root ./wiki <command>
 ```
 
 Run `... help` for the full command reference. Key commands:

--- a/wiki/sources/ymir-skill-dispatcher.md
+++ b/wiki/sources/ymir-skill-dispatcher.md
@@ -5,7 +5,7 @@ date: 2026-08-18
 tags: []
 source: plugins/ymir/SKILL.md
 source_path: plugins/ymir/SKILL.md
-source_hash: 31a1b4ebc0994f000bf1976bbd79e27a108d7a6671c8a18fc5fd902f70c51640
+source_hash: 69241e07617ef567f36cfd04d811c48f1545696ba7fb20c3b4d7b02b5c3c79b5
 ingested: 2026-08-18
 ---
 
@@ -68,10 +68,19 @@ If — and only if — the intent is explicitly to create the wiki
 (`ymir add context`, `ymir add wiki`), Ymir **executes** the wiki scaffold
 immediately against the project via **a single CLI call** — never by hand-editing
 files. The CLI owns the tree, the PreToolUse hook, the `.claude/settings.json`
-entry, the `CLAUDE.md` block, and the validation step. From the project root:
+entry, the `CLAUDE.md` block, and the validation step.
+
+All asset paths below (`references/`, `templates/`, `wiki-cli/`, `hooks/`) are
+**relative to this skill's root directory** — the directory that contains this
+`SKILL.md`. Resolve `$SKILL_ROOT` as that directory before running any command
+(`CLAUDE_PLUGIN_ROOT` holds it in Claude Code plugin installs; derive it from this
+file's path for skills-CLI installs).
+
+Provision the wiki binary once (idempotent), then scaffold from the project root:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/wiki-cli/bin/wiki" --root ./wiki init
+node "$SKILL_ROOT/hooks/ensure-wiki-binary.mjs"
+"$SKILL_ROOT/wiki-cli/bin/wiki" --root ./wiki init
 ```
 
 It is idempotent (safe to re-run); on success the last line is `wiki valid`. If it
@@ -123,7 +132,7 @@ in-scope concern. For each concern run the 4-move engine — **probe why → rec
 (2-3 trade-offs, recommendation first) → adaptive follow-up only when needed →
 confirm** — asking **one question per `AskUserQuestion` message**. The full engine,
 the per-concern probe bank, the rules scope-probing, and the greenfield phrasing
-live in `${CLAUDE_PLUGIN_ROOT}/references/socratic-interview.md` — read it before
+live in `references/socratic-interview.md` (relative to the skill root) — read it before
 interviewing.
 
 * For `ymir init`, sweep the whole checklist; for a narrow action (e.g. `add
@@ -131,7 +140,7 @@ interviewing.
 * The user may skip a concern → record `status: skipped` with a `reason`.
 * Write each answer into `.ymir/harness-profile.yaml` as you go, including
   `why`, `findings`, and `alternatives_considered`. Field shape:
-  `${CLAUDE_PLUGIN_ROOT}/templates/harness-profile.schema.md`.
+  `templates/harness-profile.schema.md` (relative to the skill root).
 
 ## Step 2 — Consistency + re-audit (gate)
 
@@ -157,9 +166,9 @@ Assemble the playbook from the bundled per-concern templates — do not free-for
 1. Ensure `.ymir/harness-profile.yaml` reflects the final audited decisions
    (`spec_version: 2`).
 2. Write `.ymir/harness-playbook.md`: start from
-   `${CLAUDE_PLUGIN_ROOT}/templates/playbook/header.md` (fill `{{PROJECT}}` and
+   `templates/playbook/header.md` (fill `{{PROJECT}}` and
    `{{DATE}}`), then append one section per `captured` concern from
-   `${CLAUDE_PLUGIN_ROOT}/templates/playbook/<concern>.md`, filling every `{{...}}`
+   `templates/playbook/<concern>.md`, filling every `{{...}}`
    placeholder (including the `Why / Findings` block) from the profile. Omit
    `skipped` concerns.
 3. Tell the user the spec is ready under `.ymir/`.


### PR DESCRIPTION
## Summary

- **#42** — Zero `${CLAUDE_PLUGIN_ROOT}` occurrences in `SKILL.md` and `templates/playbook/wiki.md`: asset paths (`references/`, `templates/`) are now relative to the skill root; wiki binary commands use `$SKILL_ROOT` so both skills-CLI and plugin installs resolve correctly.
- **#43** — `ensure-wiki-binary.mjs` and `wiki-sync-status.mjs` self-locate via `import.meta.url`; `CLAUDE_PLUGIN_ROOT` becomes an optional hint instead of a hard requirement, eliminating the unconditional `exit(2)` when it is absent.
- **#45** — The emitted `wiki/SCHEMA.md` now receives the concrete wiki binary path at scaffold time (`{{WIKI_BIN}}` placeholder replaced by `realpathSync(process.argv[0])` in `runInit`) instead of the environment-variable reference that never resolves under a skills install.

Part of #40.

## Test plan

- [ ] `bun run typecheck` — green
- [ ] `bun test` (240 tests) — all pass
- [ ] New `test/path-portability.test.ts` asserts:
  - Zero `${CLAUDE_PLUGIN_ROOT}` in `SKILL.md`, `templates/playbook/wiki.md`, and the `SCHEMA.md` source template
  - `ensure-wiki-binary.mjs` uses `import.meta.url` and does not unconditionally exit(2)
  - `wiki-sync-status.mjs` handles absent `CLAUDE_PLUGIN_ROOT` gracefully
  - `runInit` replaces `{{WIKI_BIN}}` with the injected binary path (no placeholder left in emitted SCHEMA.md)
- [ ] `init.test.ts` gains assertion that `{{WIKI_BIN}}` is replaced in emitted SCHEMA.md
- [ ] CI green before merge

Fixes #42
Fixes #43
Fixes #45