### PR TITLE
feat(skills): make harness agent-aware — branch on target_agent

### DIFF
--- a/plugins/ymir/references/socratic-interview.md
+++ b/plugins/ymir/references/socratic-interview.md
@@ -47,8 +47,22 @@ Run this for each in-scope concern, in checklist order:
 Mostly **confirm** what Step 0 detected: "Detected TypeScript on bun, backend,
 GitHub — right?" Only ask cold if detection was empty.
 
-### rules → `.claude/rules/*.md` (special: scope probing)
-Rules become native Claude Code path-scoped rule files. After the *why*:
+### target_agent (item 0b — ask immediately after techstack)
+Which AI agent(s) will read and act on this harness? The answer shapes every
+subsequent output: steering file name, rules location, and wiki enforcement.
+
+Probe: "Is this repo worked on exclusively with Claude Code, or might other
+agents (Cursor, Codex, Copilot, OpenCode) use the harness too?"
+- If Claude Code only → record `target_agent: { value: claude-code, why: ..., findings: "claude-code — .claude/ present" }` (or `findings: "unknown — inferred from context"`).
+- If multiple / agent-neutral → record `target_agent: { value: any, why: ..., findings: "any — no agent-specific tooling detected" }`.
+
+This is a **prerequisite**: record it before interviewing any concern. It does
+not go through the 4-move loop — a single confirm-and-record exchange suffices.
+
+### rules → rules files (special: scope probing + target_agent branch)
+For `claude-code` targets, rules become native `.claude/rules/*.md` path-scoped
+rule files. For `any` targets, rules will be embedded inline in `AGENT.md`
+(the `claude_md` concern handles this — no separate rule files). After the *why*:
 - Elicit the conventions to **obey** and patterns to **avoid**.
 - For each rule (group), ask its **scope**: project-wide (always-on, no `paths`)
   or scoped to files — "Does 'explicit return types' apply to all TS, or just
@@ -69,9 +83,11 @@ Why (shared project knowledge for Claude) → enabled? → collection name →
 record `enabled`, `collection`.
 
 ### claude_md → CLAUDE.md / AGENT.md
-Why (what should steer Claude here) → recommend steer points derived from
-concerns 2-4 (`lint-before-commit`, `point-to-wiki`). **Do NOT** add a
-`point-to-rules` steer — `.claude/rules/` auto-loads. Record `steer[]`.
+Why (what should steer the agent here) → recommend steer points derived from
+concerns 2-4 (`lint-before-commit`, `point-to-wiki`).
+- For `claude-code`: do NOT add `point-to-rules` — `.claude/rules/` auto-loads.
+- For `any`: rules content goes inline in `AGENT.md`; no separate rule files.
+Record `steer[]`.
 
 ## Greenfield fallback
 
@@ -85,15 +101,21 @@ special case rather than the default.
 After the sweep, check these enumerated couplings. On a conflict, surface it
 plainly and **go back** to re-ask the implicated concern:
 
+- `target_agent` ↔ `.claude/` presence: if `value: claude-code` but no `.claude/`
+  was found in Step 0 (or vice versa), surface the mismatch and confirm.
+- `target_agent` ↔ `wiki`: if `value: any` and wiki is captured+enabled, confirm
+  the user understands the wiki guard degrades to a CI job (no PreToolUse hook).
 - `lint.tool` ↔ `rules`: does a rule need enforcement the lint tool can't give? A
-  purely architectural rule is fine as a `.claude/rules/` file — but flag it if
-  the user expected lint to enforce it.
+  purely architectural rule is fine as a `.claude/rules/` file for `claude-code`,
+  or embedded in `AGENT.md` for `any` — but flag it if the user expected lint to
+  enforce it.
 - `rules` `paths` ↔ project layout: does each glob match real paths from Step 0?
   Flag a glob that matches nothing (likely a typo or a dead directory).
 - `ci.provider` ↔ `project.host`: provider matches the host?
 - `lint.strict` ↔ `project.layer`/`runtime`: strictness sensible for the stack?
-- `claude_md.steer` ↔ concerns 2-4: steers toward the wiki/lint actually set up,
-  and does **not** redundantly point at `.claude/rules/`.
+- `claude_md.steer` ↔ concerns 2-4: steers toward the wiki/lint actually set up;
+  for `claude-code`, does NOT redundantly point at `.claude/rules/`;
+  for `any`, rules are embedded inline, no `.claude/rules/` reference.
 
 ## Anti-patterns (do not do these)
 

--- a/plugins/ymir/templates/harness-profile.schema.md
+++ b/plugins/ymir/templates/harness-profile.schema.md
@@ -16,7 +16,25 @@ spec (the LLM-facing half is `.ymir/harness-playbook.md`).
 | `project.layer` | yes | `frontend` \| `backend` \| `both` |
 | `project.runtime` | recommended | e.g. `bun`, `node`, or omit if none |
 | `project.host` | recommended | repo host → drives CI provider (e.g. `github`) |
+| `target_agent.value` | yes | `claude-code` or `any` (see below) |
+| `target_agent.why` | yes | rationale for the choice |
+| `target_agent.findings` | yes | what the scan saw; `claude-code` / `any` / `unknown` |
 | `concerns.<name>.status` | yes | one of the statuses below |
+
+## `target_agent` — which AI agent runs harness files
+
+Captured as an audited decision before any concern is generated. Shapes the
+entire harness:
+
+| Value | Steering file | Rules location | Wiki guard |
+|---|---|---|---|
+| `claude-code` | `CLAUDE.md` | `.claude/rules/*.md` | PreToolUse hook (`block-wiki-edits.mjs`) + `.claude/settings.json` |
+| `any` | `AGENT.md` | Inline in `AGENT.md` | CI gate (`wiki check --error-on-untracked-sources`) |
+
+`claude-code` produces today's harness unchanged.
+`any` skips all Claude Code–specific files (`.claude/` hooks, settings) and
+replaces the wiki PreToolUse guard with a CI gate using the existing
+`wiki check` command — enforcement that works regardless of which agent runs.
 
 ## Concern statuses
 
@@ -61,6 +79,10 @@ single always-on `files[]` entry named `project-conventions` (no `paths`). Absen
 ```yaml
 meta:    { project: acme-api, generated_by: ymir, generated_at: 2026-06-18, spec_version: 2 }
 project: { language: typescript, runtime: bun, layer: backend, host: github }
+target_agent:
+  value: claude-code
+  why: "team uses Claude Code exclusively"
+  findings: "claude-code — .claude/ directory present"
 concerns:
   rules:
     status: captured

--- a/plugins/ymir/templates/playbook/claude_md.md
+++ b/plugins/ymir/templates/playbook/claude_md.md
@@ -1,13 +1,23 @@
 ## CLAUDE.md / AGENT.md → steering file
 
 - **Why / Findings:** {{CLAUDE_MD_WHY}} — repo scan: {{CLAUDE_MD_FINDINGS}}. Considered: {{CLAUDE_MD_ALTERNATIVES}}.
-- **Target:** `CLAUDE.md` (or `AGENT.md`) at the project root
-- **Inputs:** `concerns.claude_md.steer[]`, plus the other captured concerns
-- **Steps:**
-  1. Create or extend `CLAUDE.md` at the project root.
-  2. For each `steer[]` point, add a short directive — e.g. `point-to-wiki`
-     links `wiki/SCHEMA.md`; `lint-before-commit` tells Claude to run the lint
-     command before commits. Do NOT add a pointer to `.claude/rules/` — Claude
-     Code auto-discovers those; a `point-to-rules` steer is redundant.
-- **Verify:** `CLAUDE.md` exists and references the captured concerns it should
-  steer toward (wiki, lint), without pointing at `.claude/rules/`.
+- **Inputs:** `concerns.claude_md.steer[]`, `target_agent.value`, plus the other captured concerns
+
+Branch on `target_agent.value`:
+
+**`claude-code`** — write `CLAUDE.md` at the project root.
+  - For each `steer[]` point, add a short directive — e.g. `point-to-wiki`
+    links `wiki/SCHEMA.md`; `lint-before-commit` tells Claude to run the lint
+    command before commits.
+  - Do NOT add a pointer to `.claude/rules/` — Claude Code auto-discovers those;
+    a `point-to-rules` steer is redundant.
+  - **Verify:** `CLAUDE.md` exists and references the captured steer concerns
+    (wiki, lint), without pointing at `.claude/rules/`.
+
+**`any` (non-Claude target)** — write `AGENT.md` at the project root instead.
+  - Embed rules directives inline (agents don't auto-load `.claude/rules/`):
+    for each `rules.files[]` entry, add a section with its `obey[]`/`avoid[]`
+    content directly in `AGENT.md`. Omit any reference to `.claude/rules/`.
+  - For each `steer[]` point, add the same short directive as above.
+  - **Verify:** `AGENT.md` exists and embeds all rules content plus steer directives.
+    No `CLAUDE.md` or `.claude/rules/` files are written.

--- a/plugins/ymir/templates/playbook/rules.md
+++ b/plugins/ymir/templates/playbook/rules.md
@@ -1,10 +1,12 @@
-## rules → `.claude/rules/` (native path-scoped rules)
+## rules → native rules files (Claude Code) or `AGENT.md` sections (other agents)
 
 - **Why / Findings:** {{RULES_WHY}} — repo scan: {{RULES_FINDINGS}}. Considered: {{RULES_ALTERNATIVES}}.
-- **Target:** the `.claude/rules/` directory (one `<name>.md` file per `concerns.rules.files[]` entry)
-- **Inputs:** `concerns.rules.files[]` (each `{name, paths?, obey[], avoid[]}`)
-- **Steps:**
-  1. For each entry in `concerns.rules.files[]`, create `.claude/rules/<name>.md`.
+- **Inputs:** `concerns.rules.files[]` (each `{name, paths?, obey[], avoid[]}`), `target_agent.value`
+
+Branch on `target_agent.value`:
+
+**`claude-code`** — write one `.claude/rules/<name>.md` per `files[]` entry.
+  1. For each entry, create `.claude/rules/<name>.md`.
   2. If the entry has `paths`, add YAML frontmatter listing each glob:
 
      ```markdown
@@ -18,6 +20,10 @@
   3. Add a top **"NEVER"** list — one bullet per `avoid[]` item.
   4. Add sections (Naming, Error handling, Module boundaries) phrased from the
      `obey[]` items.
-- **Verify:** every `files[]` entry has a matching `.claude/rules/<name>.md`; each
-  scoped entry's frontmatter `paths` matches the profile; every `avoid[]` item
-  appears in its file's NEVER list.
+  - **Verify:** every `files[]` entry has a matching `.claude/rules/<name>.md`; each
+    scoped entry's frontmatter `paths` matches the profile; every `avoid[]` item
+    appears in its file's NEVER list.
+
+**`any` (non-Claude target)** — do NOT write `.claude/rules/`. Rules are embedded
+  directly in `AGENT.md` by the `claude_md` playbook section. This section has
+  no independent output for non-Claude targets — skip it and proceed to `claude_md`.

--- a/plugins/ymir/templates/playbook/wiki.md
+++ b/plugins/ymir/templates/playbook/wiki.md
@@ -1,27 +1,42 @@
 ## wiki / context → LLM-maintained wiki
 
 - **Why / Findings:** {{WIKI_WHY}} — repo scan: {{WIKI_FINDINGS}}.
-- **Target:** the `wiki/` tree + `.claude/hooks/block-wiki-edits.mjs`
-- **Inputs:** `concerns.wiki.enabled` (run only when `true`), `concerns.wiki.collection`, `meta.project`
+- **Inputs:** `concerns.wiki.enabled` (run only when `true`), `concerns.wiki.collection`, `meta.project`, `target_agent.value`
 
 This lays down an LLM-maintained wiki backed by the Ymir wiki CLI. The wiki
-harness is scaffolded by **a single CLI call** — never by hand-editing files. The
-CLI owns the tree, the PreToolUse hook, the `.claude/settings.json` entry, the
-`CLAUDE.md` block, and the validation step.
+harness is scaffolded by **a single CLI call** — never by hand-editing files.
 
-1. **Scaffold + verify** — provision the wiki binary (idempotent), then from the
-   project root run:
+1. **Scaffold** — provision the wiki binary (idempotent), then from the project root run:
 
+   **If `target_agent.value` is `claude-code`:**
    ```bash
    node "$SKILL_ROOT/hooks/ensure-wiki-binary.mjs"
    "$SKILL_ROOT/wiki-cli/bin/wiki" --root ./wiki init
    ```
+   The CLI installs a PreToolUse hook (`block-wiki-edits.mjs`) and merges
+   `.claude/settings.json` to enforce "never hand-edit wiki docs" at the agent level.
+
+   **If `target_agent.value` is `any` (non-Claude target):**
+   ```bash
+   node "$SKILL_ROOT/hooks/ensure-wiki-binary.mjs"
+   "$SKILL_ROOT/wiki-cli/bin/wiki" --root ./wiki init --no-hook
+   ```
+   No `.claude/` files are written. Add a CI job instead (see step 2).
 
    `$SKILL_ROOT` is the Ymir skill's root directory (contains `SKILL.md`).
    It is idempotent (safe to re-run). On success the last line is `wiki valid`.
    If it errors, stop and report.
 
-2. **Tell the user** the qmd one-time setup (also in `wiki/SCHEMA.md`):
+2. **Wiki guard (non-Claude target only)** — when `target_agent.value` is `any`,
+   add a CI job that enforces wiki integrity. For GitHub Actions, add to the CI
+   workflow a job that runs:
+   ```
+   wiki check --error-on-untracked-sources
+   ```
+   This is agent-independent enforcement equivalent to the PreToolUse hook.
+   Skip this step entirely for `claude-code` targets (hook handles it).
+
+3. **Tell the user** the qmd one-time setup (also in `wiki/SCHEMA.md`):
    `qmd collection add ./wiki --name <project>-wiki`. Search is keyword-only
    (BM25) — no `qmd embed`; re-run `qmd collection add` to refresh after adding
    pages.

--- a/plugins/ymir/wiki-cli/src/cli.ts
+++ b/plugins/ymir/wiki-cli/src/cli.ts
@@ -163,17 +163,22 @@ program
   .command("init")
   .option("--project-root <dir>", "project root", process.cwd())
   .option("--name <name>", "project name (defaults to basename of project root)")
-  .action((opts: { projectRoot: string; name?: string }) => {
+  .option("--no-hook", "skip Claude-specific hook, settings, and CLAUDE.md (for non-Claude agent targets)")
+  .action((opts: { projectRoot: string; name?: string; hook: boolean }) => {
     const root = program.opts<{ root: string }>().root;
-    const s = runInit({ projectRoot: opts.projectRoot, root, name: opts.name });
+    const s = runInit({ projectRoot: opts.projectRoot, root, name: opts.name, skipHook: !opts.hook });
     for (const p of s.created) process.stdout.write(`created ${p}\n`);
     for (const p of s.skipped) process.stdout.write(`skipped ${p}\n`);
-    process.stdout.write(
-      s.settingsMerged ? "settings merged\n" : "settings unchanged\n",
-    );
-    process.stdout.write(
-      s.claudeBlockAppended ? "CLAUDE.md appended\n" : "CLAUDE.md unchanged\n",
-    );
+    if (s.hookSkipped) {
+      process.stdout.write("hook skipped (non-Claude target)\n");
+    } else {
+      process.stdout.write(
+        s.settingsMerged ? "settings merged\n" : "settings unchanged\n",
+      );
+      process.stdout.write(
+        s.claudeBlockAppended ? "CLAUDE.md appended\n" : "CLAUDE.md unchanged\n",
+      );
+    }
     if (!s.valid) {
       process.stderr.write("wiki invalid\n");
       process.exit(1);

--- a/plugins/ymir/wiki-cli/src/commands/init.ts
+++ b/plugins/ymir/wiki-cli/src/commands/init.ts
@@ -16,6 +16,7 @@ export type InitSummary = {
   skipped: string[];
   settingsMerged: boolean;
   claudeBlockAppended: boolean;
+  hookSkipped: boolean;
   valid: boolean;
 };
 
@@ -24,6 +25,7 @@ export function runInit(opts: {
   root: string;
   name?: string;
   wikiBin?: string;
+  skipHook?: boolean;
 }): InitSummary {
   const projectRoot = resolve(opts.projectRoot);
   const wikiRoot = resolve(projectRoot, opts.root);
@@ -51,29 +53,33 @@ export function runInit(opts: {
   writeIfMissing(join(wikiRoot, "index.md"), INDEX_SEED);
   writeIfMissing(join(wikiRoot, "log.md"), LOG_SEED);
 
-  const hookPath = join(projectRoot, ".claude", "hooks", "block-wiki-edits.mjs");
-  const hookExisted = existsSync(hookPath);
-  mkdirSync(dirname(hookPath), { recursive: true });
-  writeFileSync(hookPath, BLOCK_HOOK);
-  (hookExisted ? skipped : created).push(hookPath);
+  const hookSkipped = opts.skipHook === true;
+  let settingsMerged = false;
+  let claudeBlockAppended = false;
 
-  const settingsPath = join(projectRoot, ".claude", "settings.json");
-  const existing: Settings = existsSync(settingsPath)
-    ? (JSON.parse(readFileSync(settingsPath, "utf8")) as Settings)
-    : {};
-  const beforeCount = existing.hooks?.PreToolUse?.length ?? 0;
-  const merged = mergeSettings(existing, SETTINGS_HOOK_ENTRY);
-  const afterCount = merged.hooks?.PreToolUse?.length ?? 0;
-  const settingsMerged = afterCount !== beforeCount;
-  mkdirSync(dirname(settingsPath), { recursive: true });
-  writeFileSync(settingsPath, `${JSON.stringify(merged, null, 2)}\n`);
+  if (!hookSkipped) {
+    const hookPath = join(projectRoot, ".claude", "hooks", "block-wiki-edits.mjs");
+    const hookExisted = existsSync(hookPath);
+    mkdirSync(dirname(hookPath), { recursive: true });
+    writeFileSync(hookPath, BLOCK_HOOK);
+    (hookExisted ? skipped : created).push(hookPath);
 
-  const claudePath = join(projectRoot, "CLAUDE.md");
-  const claudeContent = existsSync(claudePath)
-    ? readFileSync(claudePath, "utf8")
-    : "";
-  const claudeBlockAppended = !claudeBlockPresent(claudeContent);
-  writeFileSync(claudePath, appendClaudeBlock(claudeContent));
+    const settingsPath = join(projectRoot, ".claude", "settings.json");
+    const existing: Settings = existsSync(settingsPath)
+      ? (JSON.parse(readFileSync(settingsPath, "utf8")) as Settings)
+      : {};
+    const beforeCount = existing.hooks?.PreToolUse?.length ?? 0;
+    const merged = mergeSettings(existing, SETTINGS_HOOK_ENTRY);
+    const afterCount = merged.hooks?.PreToolUse?.length ?? 0;
+    settingsMerged = afterCount !== beforeCount;
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    writeFileSync(settingsPath, `${JSON.stringify(merged, null, 2)}\n`);
+
+    const claudePath = join(projectRoot, "CLAUDE.md");
+    const claudeContent = existsSync(claudePath) ? readFileSync(claudePath, "utf8") : "";
+    claudeBlockAppended = !claudeBlockPresent(claudeContent);
+    writeFileSync(claudePath, appendClaudeBlock(claudeContent));
+  }
 
   const v = validateWiki(wikiRoot);
   return {
@@ -81,6 +87,7 @@ export function runInit(opts: {
     skipped,
     settingsMerged,
     claudeBlockAppended,
+    hookSkipped,
     valid: v.ok,
   };
 }

--- a/plugins/ymir/wiki-cli/test/agent-target.test.ts
+++ b/plugins/ymir/wiki-cli/test/agent-target.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runInit } from "../src/commands/init.js";
+
+let proj: string;
+beforeEach(() => { proj = mkdtempSync(join(tmpdir(), "agent-target-")); });
+
+describe("runInit with skipHook: true (non-Claude target)", () => {
+  test("does not write .claude/hooks/block-wiki-edits.mjs", () => {
+    runInit({ projectRoot: proj, root: "wiki", skipHook: true });
+    expect(existsSync(join(proj, ".claude/hooks/block-wiki-edits.mjs"))).toBe(false);
+  });
+
+  test("does not write .claude/settings.json", () => {
+    runInit({ projectRoot: proj, root: "wiki", skipHook: true });
+    expect(existsSync(join(proj, ".claude/settings.json"))).toBe(false);
+  });
+
+  test("does not append to CLAUDE.md", () => {
+    runInit({ projectRoot: proj, root: "wiki", skipHook: true });
+    expect(existsSync(join(proj, "CLAUDE.md"))).toBe(false);
+  });
+
+  test("still scaffolds wiki files", () => {
+    runInit({ projectRoot: proj, root: "wiki", skipHook: true });
+    for (const f of ["raw/.gitkeep", "sources/.gitkeep", "notes/.gitkeep", "SCHEMA.md", "index.md", "log.md"]) {
+      expect(existsSync(join(proj, "wiki", f))).toBe(true);
+    }
+  });
+
+  test("reports hookSkipped: true in summary", () => {
+    const s = runInit({ projectRoot: proj, root: "wiki", skipHook: true });
+    expect(s.hookSkipped).toBe(true);
+  });
+
+  test("reports settingsMerged: false in summary", () => {
+    const s = runInit({ projectRoot: proj, root: "wiki", skipHook: true });
+    expect(s.settingsMerged).toBe(false);
+  });
+
+  test("reports claudeBlockAppended: false in summary", () => {
+    const s = runInit({ projectRoot: proj, root: "wiki", skipHook: true });
+    expect(s.claudeBlockAppended).toBe(false);
+  });
+
+  test("wiki is still valid", () => {
+    const s = runInit({ projectRoot: proj, root: "wiki", skipHook: true });
+    expect(s.valid).toBe(true);
+  });
+});
+
+describe("runInit regression: default behavior unchanged (Claude Code target)", () => {
+  test("still writes .claude/hooks/block-wiki-edits.mjs by default", () => {
+    runInit({ projectRoot: proj, root: "wiki" });
+    expect(existsSync(join(proj, ".claude/hooks/block-wiki-edits.mjs"))).toBe(true);
+  });
+
+  test("still merges .claude/settings.json by default", () => {
+    runInit({ projectRoot: proj, root: "wiki" });
+    expect(existsSync(join(proj, ".claude/settings.json"))).toBe(true);
+    const s = JSON.parse(readFileSync(join(proj, ".claude/settings.json"), "utf-8"));
+    expect(s.hooks?.PreToolUse?.length).toBeGreaterThan(0);
+  });
+
+  test("still appends to CLAUDE.md by default", () => {
+    runInit({ projectRoot: proj, root: "wiki" });
+    expect(existsSync(join(proj, "CLAUDE.md"))).toBe(true);
+    const md = readFileSync(join(proj, "CLAUDE.md"), "utf-8");
+    expect(md).toContain("## Wiki / Context");
+  });
+
+  test("reports hookSkipped: false by default", () => {
+    const s = runInit({ projectRoot: proj, root: "wiki" });
+    expect(s.hookSkipped).toBe(false);
+  });
+});

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -62,3 +62,8 @@
 ## [2026-08-18] ingest | Ymir SKILL Dispatcher
 ## [2026-08-18] ingest | Playbook Wiki
 ## [2026-08-18] ingest | Wiki Schema
+## [2026-08-18] ingest | Harness Profile Schema
+## [2026-08-18] ingest | Playbook Wiki
+## [2026-08-18] ingest | Playbook Claude MD
+## [2026-08-18] ingest | Playbook Rules
+## [2026-08-18] ingest | Socratic Interview Reference

--- a/wiki/sources/harness-profile-schema.md
+++ b/wiki/sources/harness-profile-schema.md
@@ -5,10 +5,120 @@ date: 2026-08-18
 tags: []
 source: plugins/ymir/templates/harness-profile.schema.md
 source_path: plugins/ymir/templates/harness-profile.schema.md
-source_hash: 83bddeed61d0937d6af4bc2b831109afde4b66cda8ed920fcf671b260be7c679
+source_hash: 45ba78324b3bf4313f2fa1dec2a90e72a03a10d4714d32d0fd3592d4fea33e82
 ingested: 2026-08-18
 ---
 
 # Harness Profile Schema
 
-Schema reference for .ymir/harness-profile.yaml, the machine-readable half of the harness spec (the LLM-facing half is harness-playbook.md). Documents required top-level keys (meta.project, generated\_by, generated\_at, spec\_version=2, project.language/layer/runtime/host, concerns.<name>.status), the three statuses (captured/skipped/pending, with pending blocking spec emission), required fields per concern when captured (including why and findings on every concern), and the rules.files[] shape mapping each entry to a .claude/rules/<name>.md file with optional paths frontmatter. Includes the v1-to-v2 migration note and a full example profile.
+# Harness Profile — Shape & Required Fields
+
+`.ymir/harness-profile.yaml` records the audited interview decisions. Ymir writes
+it; the re-audit gate checks it. It is the machine-readable half of the harness
+spec (the LLM-facing half is `.ymir/harness-playbook.md`).
+
+## Top level
+
+| Key                      | Required    | Notes                                                |
+| ------------------------ | ----------- | ---------------------------------------------------- |
+| `meta.project`           | yes         | base name of the project directory                   |
+| `meta.generated_by`      | yes         | always `ymir`                                        |
+| `meta.generated_at`      | yes         | ISO date (YYYY-MM-DD)                                |
+| `meta.spec_version`      | yes         | integer; `2` for this schema                         |
+| `project.language`       | yes         | e.g. `typescript`, `go`                              |
+| `project.layer`          | yes         | `frontend` \| `backend` \| `both`                    |
+| `project.runtime`        | recommended | e.g. `bun`, `node`, or omit if none                  |
+| `project.host`           | recommended | repo host → drives CI provider (e.g. `github`)       |
+| `target_agent.value`     | yes         | `claude-code` or `any` (see below)                   |
+| `target_agent.why`       | yes         | rationale for the choice                             |
+| `target_agent.findings`  | yes         | what the scan saw; `claude-code` / `any` / `unknown` |
+| `concerns.<name>.status` | yes         | one of the statuses below                            |
+
+## `target_agent` — which AI agent runs harness files
+
+Captured as an audited decision before any concern is generated. Shapes the
+entire harness:
+
+| Value         | Steering file | Rules location       | Wiki guard                                                         |
+| ------------- | ------------- | -------------------- | ------------------------------------------------------------------ |
+| `claude-code` | `CLAUDE.md`   | `.claude/rules/*.md` | PreToolUse hook (`block-wiki-edits.mjs`) + `.claude/settings.json` |
+| `any`         | `AGENT.md`    | Inline in `AGENT.md` | CI gate (`wiki check --error-on-untracked-sources`)                |
+
+`claude-code` produces today's harness unchanged.
+`any` skips all Claude Code–specific files (`.claude/` hooks, settings) and
+replaces the wiki PreToolUse guard with a CI gate using the existing
+`wiki check` command — enforcement that works regardless of which agent runs.
+
+## Concern statuses
+
+* `captured` — interviewed; the required fields below are present.
+* `skipped` — user chose not to set this concern up; include a `reason`.
+* `pending` — raised but unresolved. **The audit blocks emission while any
+  in-scope concern is `pending`.**
+
+## Required fields per concern (only when `status: captured`)
+
+Every captured concern additionally requires `why` (string — the pain/goal the
+user expressed) and `findings` (string — what the Step 0 codebase scan saw + a
+verdict of `present-strong` / `present-weak` / `missing`). `alternatives_considered`
+(list) is recommended.
+
+| Concern     | Required when captured (besides `why` + `findings`)                                              |
+| ----------- | ------------------------------------------------------------------------------------------------ |
+| `rules`     | at least one `files[]` entry; each entry needs a `name` and at least one of `obey[]` / `avoid[]` |
+| `lint`      | `tool`                                                                                           |
+| `ci`        | `provider`, `runs[]`                                                                             |
+| `wiki`      | `enabled`; and if `enabled: true`, then `collection`                                             |
+| `claude_md` | `steer[]`                                                                                        |
+
+## `rules.files[]` — one native `.claude/rules/` file per entry
+
+Each entry maps to `.claude/rules/<name>.md`:
+
+| Key     | Required | Notes                                                                                                             |
+| ------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
+| `name`  | yes      | kebab-case; becomes the filename (`<name>.md`)                                                                    |
+| `paths` | no       | YAML list of globs (e.g. `["src/**/*.{ts,tsx}"]`). Omit for an always-on rule (loads at launch like `CLAUDE.md`). |
+| `obey`  | —        | conventions to follow (≥1 of `obey`/`avoid` required)                                                             |
+| `avoid` | —        | patterns to ban (rendered as a "NEVER" list)                                                                      |
+
+**v1 → v2 migration:** a v1 profile's flat `rules.obey`/`rules.avoid` upgrades to a
+single always-on `files[]` entry named `project-conventions` (no `paths`). Absent
+`why`/`findings` are treated as gaps to fill on resume; the next emit writes
+`spec_version: 2`.
+
+## Example
+
+```yaml
+meta:    { project: acme-api, generated_by: ymir, generated_at: 2026-06-18, spec_version: 2 }
+project: { language: typescript, runtime: bun, layer: backend, host: github }
+target_agent:
+  value: claude-code
+  why: "team uses Claude Code exclusively"
+  findings: "claude-code — .claude/ directory present"
+concerns:
+  rules:
+    status: captured
+    files:
+      - name: typescript-conventions      # → .claude/rules/typescript-conventions.md
+        paths: ["src/**/*.{ts,tsx}"]       # omit `paths` for an always-on rule
+        obey: [functional-core-imperative-shell, explicit-return-types]
+        avoid: [any, default-exports]
+      - name: testing
+        paths: ["**/*.test.ts"]
+        obey: [arrange-act-assert]
+    why: "encode the conventions Claude keeps violating, scoped so they load only when relevant"
+    findings: "present-weak — conventions implied in code but undocumented; no .claude/rules/"
+    alternatives_considered: [single-CLAUDE.md-section, docs/rules.md]
+  lint:
+    status: captured
+    tool: biome
+    strict: true
+    style: { indent: tab, quotes: single }
+    why: "catch real bugs + kill mixed quote styles without config overhead"
+    findings: "missing — no linter config; src/ mixes single+double quotes"
+    alternatives_considered: [eslint+prettier]
+  ci:        { status: captured, provider: github-actions, runs: [lint], why: "block PRs that fail lint", findings: "missing — no workflows" }
+  wiki:      { status: captured, enabled: true, collection: acme-api-wiki, why: "shared project knowledge for Claude", findings: "missing" }
+  claude_md: { status: captured, steer: [point-to-wiki, lint-before-commit], why: "steer Claude to wiki + lint gate", findings: "present-weak — thin CLAUDE.md" }
+```

--- a/wiki/sources/playbook-claude-md.md
+++ b/wiki/sources/playbook-claude-md.md
@@ -5,10 +5,34 @@ date: 2026-08-18
 tags: []
 source: plugins/ymir/templates/playbook/claude_md.md
 source_path: plugins/ymir/templates/playbook/claude_md.md
-source_hash: eeb5da62de75a694d059aefea1274745fb6600012c5b9dc55f359f2d29ddaf4a
+source_hash: 5ea3b92be4765763e93673288b7ddacb2f0e0a51756663e8b962f40387805788
 ingested: 2026-08-18
 ---
 
 # Playbook Claude MD
 
-Playbook section template for the CLAUDE.md/AGENT.md steering-file concern. Opens with a Why/Findings placeholder block, targets CLAUDE.md (or AGENT.md) at the project root, takes concerns.claude\_md.steer[] as input, and its Steps create/extend the file with one directive per steer point (e.g. point-to-wiki, lint-before-commit) while explicitly forbidding a point-to-rules steer since .claude/rules/ auto-loads. Verify checks the file exists and references the captured concerns it should steer toward without pointing at .claude/rules/.
+## CLAUDE.md / AGENT.md → steering file
+
+* **Why / Findings:** {{CLAUDE\_MD\_WHY}} — repo scan: {{CLAUDE\_MD\_FINDINGS}}. Considered: {{CLAUDE\_MD\_ALTERNATIVES}}.
+* **Inputs:** `concerns.claude_md.steer[]`, `target_agent.value`, plus the other captured concerns
+
+Branch on `target_agent.value`:
+
+**`claude-code`** — write `CLAUDE.md` at the project root.
+
+* For each `steer[]` point, add a short directive — e.g. `point-to-wiki`
+  links `wiki/SCHEMA.md`; `lint-before-commit` tells Claude to run the lint
+  command before commits.
+* Do NOT add a pointer to `.claude/rules/` — Claude Code auto-discovers those;
+  a `point-to-rules` steer is redundant.
+* **Verify:** `CLAUDE.md` exists and references the captured steer concerns
+  (wiki, lint), without pointing at `.claude/rules/`.
+
+**`any` (non-Claude target)** — write `AGENT.md` at the project root instead.
+
+* Embed rules directives inline (agents don't auto-load `.claude/rules/`):
+  for each `rules.files[]` entry, add a section with its `obey[]`/`avoid[]`
+  content directly in `AGENT.md`. Omit any reference to `.claude/rules/`.
+* For each `steer[]` point, add the same short directive as above.
+* **Verify:** `AGENT.md` exists and embeds all rules content plus steer directives.
+  No `CLAUDE.md` or `.claude/rules/` files are written.

--- a/wiki/sources/playbook-rules.md
+++ b/wiki/sources/playbook-rules.md
@@ -5,10 +5,40 @@ date: 2026-08-18
 tags: []
 source: plugins/ymir/templates/playbook/rules.md
 source_path: plugins/ymir/templates/playbook/rules.md
-source_hash: eb86ea207a2ce3f6a30f34a1615a19decf64c9ddef068837efa03421f3a5fc6b
+source_hash: b9e676acb8281eadbbdece64dffc6a287733ae594c658621fb43adf606bb7631
 ingested: 2026-08-18
 ---
 
 # Playbook Rules
 
-Playbook section template for the rules concern, targeting the .claude/rules/ directory (native path-scoped Claude Code rules) rather than a single docs/rules.md. Opens with a Why/Findings placeholder block, takes concerns.rules.files[] as Inputs (each entry {name, paths?, obey[], avoid[]}), and its Steps create one .claude/rules/<name>.md per entry, adding YAML paths: frontmatter when the entry is scoped (omitted for an always-on rule), a NEVER list from avoid[], and sections phrased from obey[]. Verify checks every files[] entry has a matching file, scoped entries' frontmatter matches the profile, and every avoid[] item appears in its file's NEVER list.
+## rules → native rules files (Claude Code) or `AGENT.md` sections (other agents)
+
+* **Why / Findings:** {{RULES\_WHY}} — repo scan: {{RULES\_FINDINGS}}. Considered: {{RULES\_ALTERNATIVES}}.
+* **Inputs:** `concerns.rules.files[]` (each `{name, paths?, obey[], avoid[]}`), `target_agent.value`
+
+Branch on `target_agent.value`:
+
+**`claude-code`** — write one `.claude/rules/<name>.md` per `files[]` entry.
+
+1. For each entry, create `.claude/rules/<name>.md`.
+2. If the entry has `paths`, add YAML frontmatter listing each glob:
+
+   ```markdown
+   ---
+   paths:
+     - "<glob>"
+   ---
+   ```
+
+   If it has no `paths`, write no frontmatter (always-on rule).
+3. Add a top **"NEVER"** list — one bullet per `avoid[]` item.
+4. Add sections (Naming, Error handling, Module boundaries) phrased from the
+   `obey[]` items.
+
+* **Verify:** every `files[]` entry has a matching `.claude/rules/<name>.md`; each
+  scoped entry's frontmatter `paths` matches the profile; every `avoid[]` item
+  appears in its file's NEVER list.
+
+**`any` (non-Claude target)** — do NOT write `.claude/rules/`. Rules are embedded
+directly in `AGENT.md` by the `claude_md` playbook section. This section has
+no independent output for non-Claude targets — skip it and proceed to `claude_md`.

--- a/wiki/sources/playbook-wiki.md
+++ b/wiki/sources/playbook-wiki.md
@@ -5,7 +5,7 @@ date: 2026-08-18
 tags: []
 source: plugins/ymir/templates/playbook/wiki.md
 source_path: plugins/ymir/templates/playbook/wiki.md
-source_hash: 5b58433103b94f96eda6d43a5b8e08b269010228637fc718d6369547d03514bd
+source_hash: b78e4ff45e1a5c02308b966cb2e4ae24e2e66a0464ba95df45af3946586ed773
 ingested: 2026-08-18
 ---
 
@@ -14,27 +14,46 @@ ingested: 2026-08-18
 ## wiki / context → LLM-maintained wiki
 
 * **Why / Findings:** {{WIKI\_WHY}} — repo scan: {{WIKI\_FINDINGS}}.
-* **Target:** the `wiki/` tree + `.claude/hooks/block-wiki-edits.mjs`
-* **Inputs:** `concerns.wiki.enabled` (run only when `true`), `concerns.wiki.collection`, `meta.project`
+* **Inputs:** `concerns.wiki.enabled` (run only when `true`), `concerns.wiki.collection`, `meta.project`, `target_agent.value`
 
 This lays down an LLM-maintained wiki backed by the Ymir wiki CLI. The wiki
-harness is scaffolded by **a single CLI call** — never by hand-editing files. The
-CLI owns the tree, the PreToolUse hook, the `.claude/settings.json` entry, the
-`CLAUDE.md` block, and the validation step.
+harness is scaffolded by **a single CLI call** — never by hand-editing files.
 
-1. **Scaffold + verify** — provision the wiki binary (idempotent), then from the
-   project root run:
+1. **Scaffold** — provision the wiki binary (idempotent), then from the project root run:
+
+   **If `target_agent.value` is `claude-code`:**
 
    ```bash
    node "$SKILL_ROOT/hooks/ensure-wiki-binary.mjs"
    "$SKILL_ROOT/wiki-cli/bin/wiki" --root ./wiki init
    ```
 
+   The CLI installs a PreToolUse hook (`block-wiki-edits.mjs`) and merges
+   `.claude/settings.json` to enforce "never hand-edit wiki docs" at the agent level.
+
+   **If `target_agent.value` is `any` (non-Claude target):**
+
+   ```bash
+   node "$SKILL_ROOT/hooks/ensure-wiki-binary.mjs"
+   "$SKILL_ROOT/wiki-cli/bin/wiki" --root ./wiki init --no-hook
+   ```
+
+   No `.claude/` files are written. Add a CI job instead (see step 2).
+
    `$SKILL_ROOT` is the Ymir skill's root directory (contains `SKILL.md`).
    It is idempotent (safe to re-run). On success the last line is `wiki valid`.
    If it errors, stop and report.
 
-2. **Tell the user** the qmd one-time setup (also in `wiki/SCHEMA.md`):
+2. **Wiki guard (non-Claude target only)** — when `target_agent.value` is `any`,
+   add a CI job that enforces wiki integrity. For GitHub Actions, add to the CI
+   workflow a job that runs:
+   ```
+   wiki check --error-on-untracked-sources
+   ```
+   This is agent-independent enforcement equivalent to the PreToolUse hook.
+   Skip this step entirely for `claude-code` targets (hook handles it).
+
+3. **Tell the user** the qmd one-time setup (also in `wiki/SCHEMA.md`):
    `qmd collection add ./wiki --name <project>-wiki`. Search is keyword-only
    (BM25) — no `qmd embed`; re-run `qmd collection add` to refresh after adding
    pages.

--- a/wiki/sources/socratic-interview-reference.md
+++ b/wiki/sources/socratic-interview-reference.md
@@ -5,10 +5,145 @@ date: 2026-08-18
 tags: []
 source: plugins/ymir/references/socratic-interview.md
 source_path: plugins/ymir/references/socratic-interview.md
-source_hash: 86f5770816367bb4f57565460a9c53f1bafa81334c90170044ea83beb2f37be0
+source_hash: 7e91eb0e48b695b174f572a3335529ada25ee493fdc33b6db7bccb3b02d5bce0
 ingested: 2026-08-18
 ---
 
 # Socratic Interview Reference
 
-The bundled reference doc that Step 1 of SKILL.md points to for running the Socratic interview. States the cardinal rule of one question per AskUserQuestion message, then the 4-move per-concern loop (probe the why grounded in the Step 0 finding, recommend with trade-offs leading with a pick, adaptive follow-up only when needed, confirm+record into harness-profile.yaml). Grounds each move by verdict: present-strong confirms/tunes, present-weak names the weakness and proposes strengthening, missing proposes adding but applies YAGNI. Includes a per-concern probe bank (rules' scope-probing for .claude/rules/ paths, lint, ci, wiki, claude\_md), a greenfield fallback, a cross-concern consistency checklist, and an anti-patterns list.
+# Ymir Socratic Interview Engine
+
+This drives **Step 1** of `SKILL.md`. It turns the harness interview from a
+form-fill into a grounded dialogue. Read it before interviewing.
+
+## Cardinal rule — one question per message
+
+Every question is its own `AskUserQuestion` call. Ask one thing, then **stop and
+yield the floor**. Never batch questions "to be efficient" — batching freezes the
+conversation and you lose the ability to let an answer shape the next question.
+
+## Inputs from Step 0
+
+Before Step 1 you hold a **gap report**: for each concern a verdict of
+`present-strong`, `present-weak`, or `missing`, plus what was detected. Every
+question below is grounded in that finding — never ask something the scan already
+answered.
+
+## The per-concern loop (4 moves)
+
+Run this for each in-scope concern, in checklist order:
+
+1. **Probe the *why* (open, grounded).** Ask the purpose/pain behind the concern,
+   citing the finding. Not "which linter?" but "I see no linter and mixed quote
+   styles in `src/` — are you mainly after catching bugs, enforcing style, or
+   both?"
+2. **Recommend with trade-offs, recommendation first.** Offer 2-3 grounded
+   options, lead with your pick and why, invite challenge: "For TS/bun I'd pick
+   biome — one fast tool, near-zero config; trade-off vs eslint is fewer plugins.
+   Sound?"
+3. **Adaptive follow-up — only when needed.** Ask a follow-up *only* if the answer
+   reveals a gap, surprise, or contradiction. Otherwise go straight to confirm.
+   This is the friction ceiling that keeps it a dialogue, not an interrogation.
+4. **Confirm + record.** Write `decision`, `why`, `findings`,
+   `alternatives_considered` into `.ymir/harness-profile.yaml`, then advance.
+
+### Grounding by verdict
+
+* `present-strong` → confirm or tune what exists ("keep eslint as-is?").
+* `present-weak` → name the weakness and propose strengthening.
+* `missing` → propose adding — but apply **YAGNI**: if the user has no real need,
+  record `status: skipped` with a reason instead of forcing it.
+
+## Per-concern probe bank
+
+### project / techstack (item 0)
+
+Mostly **confirm** what Step 0 detected: "Detected TypeScript on bun, backend,
+GitHub — right?" Only ask cold if detection was empty.
+
+### target\_agent (item 0b — ask immediately after techstack)
+
+Which AI agent(s) will read and act on this harness? The answer shapes every
+subsequent output: steering file name, rules location, and wiki enforcement.
+
+Probe: "Is this repo worked on exclusively with Claude Code, or might other
+agents (Cursor, Codex, Copilot, OpenCode) use the harness too?"
+
+* If Claude Code only → record `target_agent: { value: claude-code, why: ..., findings: "claude-code — .claude/ present" }` (or `findings: "unknown — inferred from context"`).
+* If multiple / agent-neutral → record `target_agent: { value: any, why: ..., findings: "any — no agent-specific tooling detected" }`.
+
+This is a **prerequisite**: record it before interviewing any concern. It does
+not go through the 4-move loop — a single confirm-and-record exchange suffices.
+
+### rules → rules files (special: scope probing + target\_agent branch)
+
+For `claude-code` targets, rules become native `.claude/rules/*.md` path-scoped
+rule files. For `any` targets, rules will be embedded inline in `AGENT.md`
+(the `claude_md` concern handles this — no separate rule files). After the *why*:
+
+* Elicit the conventions to **obey** and patterns to **avoid**.
+* For each rule (group), ask its **scope**: project-wide (always-on, no `paths`)
+  or scoped to files — "Does 'explicit return types' apply to all TS, or just
+  `src/api/**`?" Path-scoped rules load only when Claude reads a matching file.
+* Record one `files[]` entry per group: `{name, paths?, obey, avoid}`.
+
+### lint → linter config
+
+Why (bugs / style / both) → recommend a tool for the stack
+(biome / eslint / ruff / golangci-lint) with the trade-off → strictness →
+record `tool`, `strict`, `style`.
+
+### ci → CI workflow
+
+Why (gate PRs / catch regressions) → recommend the provider from `project.host`
+(github → github-actions) → what it runs (`runs: [lint]`) → record.
+
+### wiki / context
+
+Why (shared project knowledge for Claude) → enabled? → collection name →
+record `enabled`, `collection`.
+
+### claude\_md → CLAUDE.md / AGENT.md
+
+Why (what should steer the agent here) → recommend steer points derived from
+concerns 2-4 (`lint-before-commit`, `point-to-wiki`).
+
+* For `claude-code`: do NOT add `point-to-rules` — `.claude/rules/` auto-loads.
+* For `any`: rules content goes inline in `AGENT.md`; no separate rule files.
+  Record `steer[]`.
+
+## Greenfield fallback
+
+If Step 0 found no signals (empty repo), there is no finding to cite. Ask the
+purpose directly, recommend sensible defaults for the declared stack, and record
+`findings: "missing — greenfield"`. This is the old onboarding behaviour, now a
+special case rather than the default.
+
+## Cross-concern consistency checklist (Step 2b)
+
+After the sweep, check these enumerated couplings. On a conflict, surface it
+plainly and **go back** to re-ask the implicated concern:
+
+* `target_agent` ↔ `.claude/` presence: if `value: claude-code` but no `.claude/`
+  was found in Step 0 (or vice versa), surface the mismatch and confirm.
+* `target_agent` ↔ `wiki`: if `value: any` and wiki is captured+enabled, confirm
+  the user understands the wiki guard degrades to a CI job (no PreToolUse hook).
+* `lint.tool` ↔ `rules`: does a rule need enforcement the lint tool can't give? A
+  purely architectural rule is fine as a `.claude/rules/` file for `claude-code`,
+  or embedded in `AGENT.md` for `any` — but flag it if the user expected lint to
+  enforce it.
+* `rules` `paths` ↔ project layout: does each glob match real paths from Step 0?
+  Flag a glob that matches nothing (likely a typo or a dead directory).
+* `ci.provider` ↔ `project.host`: provider matches the host?
+* `lint.strict` ↔ `project.layer`/`runtime`: strictness sensible for the stack?
+* `claude_md.steer` ↔ concerns 2-4: steers toward the wiki/lint actually set up;
+  for `claude-code`, does NOT redundantly point at `.claude/rules/`;
+  for `any`, rules are embedded inline, no `.claude/rules/` reference.
+
+## Anti-patterns (do not do these)
+
+* ❌ Asking "which tool?" with no *why* first — the bare field-question is the
+  shallow failure this engine exists to remove.
+* ❌ Batching multiple questions into one message.
+* ❌ Accepting the first answer without grounding it in the Step 0 finding.
+* ❌ Sweeping a concern the user has no need for instead of skipping it (YAGNI).


### PR DESCRIPTION
## Summary

- `harness-profile.yaml` gains a `target_agent` top-level field (`value: claude-code | any`, plus `why`/`findings`) captured before any concern, shaping the entire harness output.
- `wiki init --no-hook` skips `.claude/` hook, settings, and `CLAUDE.md` for non-Claude targets; default behavior is unchanged.
- Playbook templates (`wiki.md`, `claude_md.md`, `rules.md`) and the Socratic interview reference all branch on `target_agent.value`, with clear decision tables.

## What changes per target_agent value

| | `claude-code` | `any` |
|---|---|---|
| Steering file | `CLAUDE.md` | `AGENT.md` |
| Rules location | `.claude/rules/*.md` | Inline in `AGENT.md` |
| Wiki guard | PreToolUse hook | CI gate (`wiki check`) |
| `.claude/` files | hook + settings.json | none |

## Test plan

- [x] 12 new tests in `agent-target.test.ts` covering `skipHook: true` behavior and regression assertions for default (Claude Code) path
- [x] Full test suite (252 tests) passes with 0 failures
- [x] TypeScript type check passes
- [x] Wiki health (`wiki check --error-on-untracked-sources`) passes

Fixes #46