### PR TITLE
docs: document skills-CLI install path, fix version, add distribution wiki source

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 [![release-please](https://github.com/muitneliss/ymir/actions/workflows/release-please.yml/badge.svg)](https://github.com/muitneliss/ymir/actions/workflows/release-please.yml)
 [![release](https://img.shields.io/github/v/release/muitneliss/ymir?sort=semver)](https://github.com/muitneliss/ymir/releases)
+[![skills.sh](https://skills.sh/b/muitneliss/ymir)](https://skills.sh/muitneliss/ymir)
 
-A Claude Code plugin marketplace + plugin that produces a **harness spec** for a
-repo — rules (as native `.claude/rules/`), lint, CI lint, wiki/context, and
-`CLAUDE.md`/`AGENT.md`.
+A Claude Code plugin and agent skill that produces a **harness spec** for a
+repo — rules, lint, CI lint, wiki/context, and `CLAUDE.md`/`AGENT.md`.
 
 Ymir does **not** generate application code. It first **explores your codebase**,
 then runs a **deep Socratic interview** — per concern it probes the *why*,
@@ -30,7 +30,7 @@ ymir/
 ├── .claude-plugin/
 │   └── marketplace.json        # the "ymir" marketplace
 └── plugins/
-    └── ymir/                   # the "ymir" plugin
+    └── ymir/                   # the "ymir" plugin / skill
         ├── .claude-plugin/
         │   └── plugin.json
         └── SKILL.md            # single dispatcher skill → /ymir
@@ -50,6 +50,8 @@ ymir revert           # undo the last apply
 
 ## Install
 
+### Claude Code plugin (recommended for Claude Code users)
+
 ```shell
 /plugin marketplace add muitneliss/ymir
 /plugin install ymir@ymir
@@ -58,16 +60,45 @@ ymir revert           # undo the last apply
 
 Then: `/ymir init for this project`
 
+The plugin marketplace installs via Claude Code's native plugin system, which
+wires up hooks automatically (including the wiki PreToolUse guard).
+
+### Agent skill via the skills CLI (Claude Code, Cursor, Codex, and others)
+
+```shell
+npx skills@latest add muitneliss/ymir
+```
+
+This installs Ymir as an agent skill under `.claude/skills/ymir/` (Claude Code)
+or the agent-specific equivalent. Distribution is purely git — `skills add` clones
+directly from this repo; there is no separate publish step.
+
+**One extra step for the wiki concern:** after `ymir apply`, if your harness
+includes the wiki concern, bootstrap the wiki binary once:
+
+```shell
+node "$SKILL_ROOT/hooks/ensure-wiki-binary.mjs"
+"$SKILL_ROOT/wiki-cli/bin/wiki" --root ./wiki init --no-hook
+```
+
+(`$SKILL_ROOT` is the directory where the skill was installed, e.g.
+`.claude/skills/ymir/` for Claude Code.)
+
+**Telemetry:** the skills CLI collects anonymous usage telemetry.
+Set `DISABLE_TELEMETRY=1` or `DO_NOT_TRACK=1` to opt out.
+
 ## Status
 
-`v0.4.0`. Ymir runs a codebase-first flow: it scans the repo, then runs a deep
+`v0.6.0`. Ymir runs a codebase-first flow: it scans the repo, then runs a deep
 per-concern Socratic interview (probe *why* → recommend → confirm, capturing
 `why`/`findings`), a consistency + reflection gate, a spec-review gate, and a spec
 emitted to `.ymir/` (`harness-profile.yaml` + `harness-playbook.md`); `ymir apply`
 then generates the harness from that spec (with backups + `ymir revert`). The
 spec's per-concern playbook sections live in `plugins/ymir/templates/playbook/`;
 the interview engine is in `plugins/ymir/references/socratic-interview.md`. The
-**rules** concern emits native `.claude/rules/*.md`. The **wiki / context** section
-drives the bundled wiki tooling (`plugins/ymir/wiki-cli`, templates, and the
-PreToolUse hook that blocks hand-editing wiki docs). The `/ymir add context` (or
-`add wiki`) intent scaffolds the wiki directly, as before.
+**rules** concern emits native `.claude/rules/*.md` for Claude Code targets, or
+embeds rules inline in `AGENT.md` for agent-neutral harnesses. The **wiki / context**
+section drives the bundled wiki tooling (`plugins/ymir/wiki-cli`, templates, and
+the PreToolUse hook for Claude Code or a CI gate for other agents). The harness
+profile records `target_agent` (claude-code or any) so every concern generates
+the right output for the chosen agent.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -67,3 +67,4 @@
 ## [2026-08-18] ingest | Playbook Claude MD
 ## [2026-08-18] ingest | Playbook Rules
 ## [2026-08-18] ingest | Socratic Interview Reference
+## [2026-08-18] ingest | Ymir README

--- a/wiki/sources/ymir-readme.md
+++ b/wiki/sources/ymir-readme.md
@@ -5,7 +5,7 @@ date: 2026-08-18
 tags: []
 source: README.md
 source_path: README.md
-source_hash: 7d8f60b034296c0d9aa2a1c6611403e7889c1b75d5f51bfc928c87f64f609da7
+source_hash: 31433bb02bca522e74e98fec20d308cb9a52d92ef6461dd7db13d340300829ea
 ingested: 2026-08-18
 ---
 
@@ -17,10 +17,10 @@ ingested: 2026-08-18
 
 [![release-please](https://github.com/muitneliss/ymir/actions/workflows/release-please.yml/badge.svg)](https://github.com/muitneliss/ymir/actions/workflows/release-please.yml)
 [![release](https://img.shields.io/github/v/release/muitneliss/ymir?sort=semver)](https://github.com/muitneliss/ymir/releases)
+[![skills.sh](https://skills.sh/b/muitneliss/ymir)](https://skills.sh/muitneliss/ymir)
 
-A Claude Code plugin marketplace + plugin that produces a **harness spec** for a
-repo — rules (as native `.claude/rules/`), lint, CI lint, wiki/context, and
-`CLAUDE.md`/`AGENT.md`.
+A Claude Code plugin and agent skill that produces a **harness spec** for a
+repo — rules, lint, CI lint, wiki/context, and `CLAUDE.md`/`AGENT.md`.
 
 Ymir does **not** generate application code. It first **explores your codebase**,
 then runs a **deep Socratic interview** — per concern it probes the *why*,
@@ -43,7 +43,7 @@ ymir/
 ├── .claude-plugin/
 │   └── marketplace.json        # the "ymir" marketplace
 └── plugins/
-    └── ymir/                   # the "ymir" plugin
+    └── ymir/                   # the "ymir" plugin / skill
         ├── .claude-plugin/
         │   └── plugin.json
         └── SKILL.md            # single dispatcher skill → /ymir
@@ -63,6 +63,8 @@ ymir revert           # undo the last apply
 
 ## Install
 
+### Claude Code plugin (recommended for Claude Code users)
+
 ```shell
 /plugin marketplace add muitneliss/ymir
 /plugin install ymir@ymir
@@ -71,16 +73,45 @@ ymir revert           # undo the last apply
 
 Then: `/ymir init for this project`
 
+The plugin marketplace installs via Claude Code's native plugin system, which
+wires up hooks automatically (including the wiki PreToolUse guard).
+
+### Agent skill via the skills CLI (Claude Code, Cursor, Codex, and others)
+
+```shell
+npx skills@latest add muitneliss/ymir
+```
+
+This installs Ymir as an agent skill under `.claude/skills/ymir/` (Claude Code)
+or the agent-specific equivalent. Distribution is purely git — `skills add` clones
+directly from this repo; there is no separate publish step.
+
+**One extra step for the wiki concern:** after `ymir apply`, if your harness
+includes the wiki concern, bootstrap the wiki binary once:
+
+```shell
+node "$SKILL_ROOT/hooks/ensure-wiki-binary.mjs"
+"$SKILL_ROOT/wiki-cli/bin/wiki" --root ./wiki init --no-hook
+```
+
+(`$SKILL_ROOT` is the directory where the skill was installed, e.g.
+`.claude/skills/ymir/` for Claude Code.)
+
+**Telemetry:** the skills CLI collects anonymous usage telemetry.
+Set `DISABLE_TELEMETRY=1` or `DO_NOT_TRACK=1` to opt out.
+
 ## Status
 
-`v0.4.0`. Ymir runs a codebase-first flow: it scans the repo, then runs a deep
+`v0.6.0`. Ymir runs a codebase-first flow: it scans the repo, then runs a deep
 per-concern Socratic interview (probe *why* → recommend → confirm, capturing
 `why`/`findings`), a consistency + reflection gate, a spec-review gate, and a spec
 emitted to `.ymir/` (`harness-profile.yaml` + `harness-playbook.md`); `ymir apply`
 then generates the harness from that spec (with backups + `ymir revert`). The
 spec's per-concern playbook sections live in `plugins/ymir/templates/playbook/`;
 the interview engine is in `plugins/ymir/references/socratic-interview.md`. The
-**rules** concern emits native `.claude/rules/*.md`. The **wiki / context** section
-drives the bundled wiki tooling (`plugins/ymir/wiki-cli`, templates, and the
-PreToolUse hook that blocks hand-editing wiki docs). The `/ymir add context` (or
-`add wiki`) intent scaffolds the wiki directly, as before.
+**rules** concern emits native `.claude/rules/*.md` for Claude Code targets, or
+embeds rules inline in `AGENT.md` for agent-neutral harnesses. The **wiki / context**
+section drives the bundled wiki tooling (`plugins/ymir/wiki-cli`, templates, and
+the PreToolUse hook for Claude Code or a CI gate for other agents). The harness
+profile records `target_agent` (claude-code or any) so every concern generates
+the right output for the chosen agent.


### PR DESCRIPTION
## Summary

- README documents both install paths (Claude Code plugin + skills CLI), what agents each reaches, and the one extra bootstrap step for skills users.
- `skills.sh` install-count badge added.
- Telemetry opt-out noted (`DISABLE_TELEMETRY=1` / `DO_NOT_TRACK=1`).
- Status version fixed: `v0.4.0` → `v0.6.0` (matches `version.txt`); Status prose updated to reflect `target_agent` branching.
- `wiki/sources/ymir-readme.md` re-ingested; `wiki check` passes.

## Accuracy guardrails (per issue)

- Does not claim skills.sh has a submission/listing process (it is just a telemetry-fed leaderboard; `skills add` is a direct git clone).
- Does not claim Ymir is Claude-Code-only.

## Test plan

- [x] Wiki health check passes (`wiki check --error-on-untracked-sources`)
- [x] CI: `test`, `wiki-health`, and `skills-install` all expected to pass

Fixes #48