### PR TITLE
test(wiki-cli): isolate ingest tests from qmd reindex

### DIFF
--- a/wiki-cli/test/ingest.test.ts
+++ b/wiki-cli/test/ingest.test.ts
@@ -13,6 +13,7 @@ describe("runIngest", () => {
     await runIngest({
       root, raw: "raw/a.pdf", title: "Doc A",
       body: "Key takeaway. See [[Doc A]].", today: "2026-06-17",
+      noReindex: true,
     });
     const page = readPage(join(root, "sources", "doc-a.md"));
     expect(page).toContain("type: source");
@@ -26,6 +27,7 @@ describe("runIngest", () => {
     await expect(runIngest({
       root, raw: "raw/a.pdf", title: "Doc A",
       body: "See [[Ghost]].", today: "2026-06-17",
+      noReindex: true,
     })).rejects.toThrow(/broken link/);
     expect(existsSync(join(root, "sources", "doc-a.md"))).toBe(false);
   });
@@ -34,12 +36,14 @@ describe("runIngest", () => {
     await runIngest({
       root, raw: "raw/a.pdf", title: "Doc A",
       body: "Original body. See [[Doc A]].", today: "2026-06-17",
+      noReindex: true,
     });
     const original = readPage(join(root, "sources", "doc-a.md"));
 
     await expect(runIngest({
       root, raw: "raw/a.pdf", title: "Doc A",
       body: "Broken update. See [[Ghost]].", today: "2026-06-18",
+      noReindex: true,
     })).rejects.toThrow(/broken link/);
 
     expect(readPage(join(root, "sources", "doc-a.md"))).toBe(original);
@@ -49,12 +53,14 @@ describe("runIngest", () => {
     await runIngest({
       root, raw: "raw/a.pdf", title: "Hiệu trưởng",
       body: "See [[Hiệu trưởng]].", today: "2026-06-17",
+      noReindex: true,
     });
     const original = readPage(join(root, "sources", "hi-u-tr-ng.md"));
 
     await expect(runIngest({
       root, raw: "raw/b.pdf", title: "Hiếu trường",
       body: "See [[Hiệu trưởng]].", today: "2026-06-18",
+      noReindex: true,
     })).rejects.toThrow(/collision/);
 
     expect(readPage(join(root, "sources", "hi-u-tr-ng.md"))).toBe(original);


### PR DESCRIPTION
## Summary
- `ingest.test.ts` tests cover ingest/validate/rollback/slug-collision behavior — not qmd reindex
- Without `noReindex: true`, each successful `runIngest` call spawns several `qmd collection` subprocesses
- With qmd installed and slow, two-call tests reliably exceeded the 5s default timeout causing flaky failures
- Reindex behavior is already fully covered by `reindex.test.ts` with a `fakeQmd` mock

## Test plan
- [x] `bun test` — 252 pass / 0 fail (was: 250 pass / 2 fail / 2 timeout)
- [x] Reindex tests unchanged and still pass via `fakeQmd` mock