### PR TITLE
feat: self-report — capture failures and file them as GitHub issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,43 @@ node "$SKILL_ROOT/hooks/ensure-wiki-binary.mjs"
 **Telemetry:** the skills CLI collects anonymous usage telemetry.
 Set `DISABLE_TELEMETRY=1` or `DO_NOT_TRACK=1` to opt out.
 
+## Self-report
+
+Ymir runs on your machine, so its failures are invisible to us unless you send
+them. When a command crashes, Ymir writes a redacted report to `~/.ymir/` and
+tells you it did. **Nothing is sent until you say so:**
+
+```shell
+wiki report          # show exactly what would be posted — sends nothing
+wiki report --yes    # file it, and opt in to filing future ones automatically
+wiki report --off    # opt out and discard everything captured
+```
+
+`wiki report` prints the literal issue body, so you can read it before deciding.
+Once you opt in, later reports are filed on their own; recurrences comment on the
+existing issue rather than opening a new one.
+
+You can also file things Ymir cannot detect itself:
+
+```shell
+wiki report --feedback "ymir apply should have a --dry-run"
+```
+
+**What a report contains:** the subcommand, error type and message, Ymir's
+version, and your OS/arch. Before anything is stored — let alone sent — it is
+stripped of filesystem paths, hostnames, email addresses, git remotes and
+credential-shaped strings. Paths inside your project keep only their
+project-relative part (`<project>/src/auth.ts`); everything else is reduced to a
+bare filename. No file contents, and no argument values, are ever included.
+
+**Delivery** uses your own `gh` login, so the issue is filed by you and Ymir
+ships no credentials. Without `gh`, you get a prefilled issue URL to open.
+
+**Opting out** — `wiki report --off`, or any of `DO_NOT_TRACK=1`,
+`DISABLE_TELEMETRY=1`, `YMIR_REPORT=off`. When off, nothing is captured at all,
+not merely withheld. Forks and internal deployments can redirect reports with
+`YMIR_REPORT_REPO=owner/name`.
+
 ## Status
 
 `v0.6.0`. Ymir runs a codebase-first flow: it scans the repo, then runs a deep

--- a/docs/superpowers/plans/2026-08-21-ymir-self-report.md
+++ b/docs/superpowers/plans/2026-08-21-ymir-self-report.md
@@ -1,0 +1,88 @@
+# Ymir Self-Report — Implementation Plan
+
+Date: 2026-08-21
+Design: `docs/superpowers/specs/2026-08-21-ymir-self-report-design.md`
+Branch: `feat/self-report`
+Status: Complete
+
+Test-driven throughout: each unit's tests were written and run red before the
+implementation existed.
+
+## Unit 1 — Redactor
+
+`wiki-cli/src/report/redact.ts`, `test/report-redact.test.ts` (32 tests).
+
+`redact(text, {cwd})` and `truncate(text, maxChars, maxLines)`. Credentials
+first, then identities, then paths. Covers each token shape, emails, SSH
+remotes, URL credentials and query strings, POSIX and Windows paths, plus
+idempotence and a no-leak property test.
+
+A non-allowlisted URL is replaced whole rather than kept: `ci.acme-corp.internal`
+names an employer as surely as a home directory names a user.
+
+## Unit 2 — Model and fingerprint
+
+`wiki-cli/src/report/model.ts`, `test/report-fingerprint.test.ts` (7 tests).
+
+Reuses the existing `sha256Hex` from `src/hash.ts`. Digit runs normalize so
+counts do not split one bug. A test pins the stack-independence.
+
+## Unit 3 — Store
+
+`wiki-cli/src/report/store.ts`, `test/report-store.test.ts` (32 tests).
+
+Consent precedence, spool merge and cap, posted map, flush window, JSONL
+adoption from hooks. Every path degrades rather than throwing — including an
+unwritable home directory.
+
+## Unit 4 — Delivery
+
+`wiki-cli/src/report/github.ts`, `test/report-github.test.ts` (18 tests).
+
+Hermetic via an injected `GhRunner`; no test touches the network. Covers the
+fallback URL and its length cap, comment-not-create on a known fingerprint, and
+the unlabelled retry for forks without a `self-report` label.
+
+## Unit 5 — Facade and command
+
+`wiki-cli/src/report.ts`, `wiki-cli/src/commands/report.ts`,
+`test/report-capture.test.ts` (20) and `test/report-cmd.test.ts` (17).
+
+`runReport` returns `{text, exitCode}`, matching `runStatus`. With no flags it
+previews and sends nothing.
+
+## Unit 6 — Error boundary
+
+`wiki-cli/src/cli.ts`, `test/cli-error-boundary.test.ts` (14 tests, subprocess).
+
+Adds `main()`, the `report` command, the opportunistic flush, and the missing
+`--version`. Fixes `note --type` to validate instead of throwing a raw ZodError.
+
+Also isolated `test/note.test.ts` from qmd reindex, as #57 did for ingest — the
+suite went from 51s with 3 timeouts to 5s green.
+
+## Unit 7 — Hook capture
+
+`plugins/ymir/hooks/ensure-wiki-binary.mjs`, `test/report-hook.test.ts` (6 tests).
+
+Seven duplicated `stderr` + `exit(2)` sites collapse into one `bail()` that also
+appends the JSONL record. Respects the opt-out env vars directly, since it runs
+before the CLI exists.
+
+## Unit 8 — Docs
+
+`README.md` (what a report contains, opt-out), `plugins/ymir/SKILL.md` (how
+Claude files skill-flow failures), `wiki/SCHEMA.md` and `src/commands/help.ts`
+(command reference), plus this plan and its design doc, all re-ingested into the
+wiki.
+
+## Verification
+
+- `bun run typecheck && bun test && bun run build` — 398 pass, 0 fail.
+- Compiled a real `bun --compile` binary and confirmed: the old ZodError dump is
+  now one line; a genuine crash spools; four crashes merge to one record with
+  `occurrences: 4`; opt-out discards and stops capture; `DO_NOT_TRACK` creates no
+  state at all; no `gh` yields a working prefilled URL.
+- Adversarial redaction pass leaked none of: real username, `ghp_` token, email,
+  secret query value, internal hostname.
+- Installed skill payload unchanged at 15 files (CI budget 20).

--- a/docs/superpowers/specs/2026-08-21-ymir-self-report-design.md
+++ b/docs/superpowers/specs/2026-08-21-ymir-self-report-design.md
@@ -1,0 +1,97 @@
+# Ymir Self-Report: capture failures and file them upstream — Design
+
+Date: 2026-08-21
+Status: Implemented
+Branch: `feat/self-report`
+
+## Problem
+
+Ymir ships to other people's machines as a Claude Code plugin and as an agent
+skill via `npx skills add`. When it breaks there, nothing comes back — the
+maintainers only learn about failures someone bothers to report by hand, which
+in practice means almost none of them.
+
+The failure experience made this worse. `wiki-cli/src/cli.ts` ended with a bare
+`program.parseAsync()` and no top-level handler, so anything an async action
+threw escaped as an unhandled rejection. Measured against the shipped compiled
+binary, `wiki note --type bogus` produced an eleven-line `ZodError` JSON dump
+followed by `Bun v1.3.14 (macOS arm64)` — and no stack frames at all, because
+`bun build --compile` emits none. The user saw noise; the project saw nothing.
+
+## Goal
+
+A failure on a user's machine becomes a deduplicated GitHub issue on
+`muitneliss/ymir`, with the user's informed consent, carrying enough to diagnose
+and nothing that identifies them.
+
+## Non-Goals (YAGNI)
+
+- No hosted ingest service and no shipped credential. Delivery borrows the user's
+  own `gh` login.
+- No background daemon and no new SessionStart hook.
+- No usage analytics. This reports *failures and feedback*, never behaviour.
+- No automatic capture of user error. A bad flag is the CLI working.
+
+## Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Consent | Opt in once, automatic after; default off | The user asked for "auto post"; publishing a stranger's error data to a public tracker unasked is not defensible |
+| Opt-out | `--off`, `DO_NOT_TRACK`, `DISABLE_TELEMETRY`, `YMIR_REPORT=off` | The README already promises the first two for the skills CLI |
+| When off | Capture nothing at all | Withholding-but-storing is not what "off" means to a user |
+| Crash path | Spool to disk only, never network | A crashing CLI must not also hang on `gh` |
+| Delivery trigger | Opportunistic flush inside the CLI | Needs no payload file, and works for skills-CLI installs on non-Claude agents where Claude Code hooks never run |
+| Identity | `sha256(kind, command, errorName, digit-normalized message)` | The compiled binary's frames are build-specific offsets; a stack-based identity is unstable or empty |
+| Dedup | Local `fingerprint → issue` map first, GitHub search second | GitHub's search index trails creation, so search-first would file duplicates for the length of the lag |
+| Destination | `muitneliss/ymir`, overridable via `YMIR_REPORT_REPO` | Forks still feed upstream; internal deployments can redirect |
+| Hook failures | Append JSONL, let the CLI complete it | A `.mjs` hook cannot import TS, and copying the pipeline in would repeat the `platform.ts` drift |
+
+## Architecture
+
+Five units inside `wiki-cli/`, so the plugin payload is unchanged (the CI
+`skills-install` job caps the installed skill at 20 files; it stays at 15).
+
+1. **`src/report/redact.ts`** — pure, no I/O. Denies by default on paths,
+   hostnames and credential shapes. Rule order is load-bearing: credentials
+   first, so a token buried in a path or query dies whatever encloses it; paths
+   last, because they are greediest.
+2. **`src/report/model.ts`** — the `Report` shape and `fingerprint()`.
+3. **`src/report/store.ts`** — all `~/.ymir` state: consent, spool, posted map,
+   flush window. Nothing here throws; every read tolerates corruption.
+4. **`src/report/github.ts`** — delivery. Injectable `GhRunner`, modelled on
+   `reindex.ts`'s never-throwing subprocess pattern. Falls back to a prefilled
+   `issues/new?…` URL when `gh` is missing or logged out.
+5. **`src/report.ts`** — the facade (`capture`, `flush`, `maybeFlush`) plus
+   `src/commands/report.ts` for the command.
+
+### Redact-then-fingerprint
+
+Redaction runs *before* the fingerprint is computed. This is load-bearing twice:
+it keeps the on-disk spool safe to read, and it makes one bug fingerprint
+identically on every machine. Fingerprinting the raw message would fold each
+user's home directory into the identity, so the same crash would arrive as a
+fresh issue from every person who hit it.
+
+### The error boundary
+
+`main()` wraps `parseAsync` and is the single place a failure becomes a message.
+Only genuine exceptions are captured; the inline `process.exit(1)` validation
+paths are correct behaviour, and reporting them would bury real bugs under
+everyone's typos.
+
+Fixing the boundary exposed a root-cause bug it would otherwise have papered
+over: `note --type` used `NoteType.parse`, throwing a raw `ZodError` for what is
+plain user error. It now validates with `safeParse` and prints one clear line.
+
+## What a report contains
+
+Subcommand, error name, redacted message and stack, flag *names*, Ymir version
+(from the `.version` stamp beside the executable), and OS/arch. Never argument
+values, file contents, or absolute paths — project paths keep only their
+relative tail (`<project>/src/auth.ts`), everything else becomes `<path>/name`.
+
+## Verification
+
+Seven test files, 398 tests green. The adversarial pass matters most: a report
+synthesized from a real home path, a `ghp_` token, an email and an internal URL
+leaks none of them into the stored bytes.

--- a/plugins/ymir/SKILL.md
+++ b/plugins/ymir/SKILL.md
@@ -263,6 +263,36 @@ End by telling the user: `ymir revert` undoes this run (run-id `<run_id>`).
 scratch have no backup; they remain and show up in `git status`. Remove them
 manually or with `git clean` for a full undo.
 
+## When something goes wrong — self-report
+
+Ymir improves from the failures people actually hit, so report them.
+
+The wiki CLI captures its own crashes with no help from you. What it cannot see
+is **this skill's flow** breaking: a playbook section missing its `**Target:**`
+line, `ymir apply` writing nothing, a profile field the interview never filled,
+an instruction here that contradicts itself. When that happens — after telling
+the user — record it:
+
+```bash
+"$SKILL_ROOT/wiki-cli/bin/wiki" report --skill \
+  --title "<one line: what broke>" \
+  --detail "<what you were doing, what you expected, what happened>"
+```
+
+Rules:
+
+- **Describe, never paste.** The detail is redacted before it is sent, but the
+  redactor is a safety net, not a licence — do not quote the user's code, file
+  contents, or `.ymir/` values into it. Name the step and the symptom.
+- **Report Ymir's faults, not the user's.** A user choosing an option you did not
+  expect is not a bug. A step that cannot be followed as written is.
+- **Report once per session** for a given failure; recurrences are merged anyway.
+- **It is captured locally, not sent.** Nothing leaves the machine until the user
+  runs `wiki report --yes`. Mention that once, then let it go — do not nag.
+
+If the user asks for a feature or complains about Ymir itself, offer to record it
+with `wiki report --feedback "<what they said>"`.
+
 ## Boundaries
 
 - Operate on the current project only ("this project" = cwd).

--- a/plugins/ymir/hooks/ensure-wiki-binary.mjs
+++ b/plugins/ymir/hooks/ensure-wiki-binary.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 import { execSync, spawnSync } from "node:child_process";
 import {
-  chmodSync, existsSync, mkdirSync,
+  appendFileSync, chmodSync, existsSync, mkdirSync,
   readFileSync, renameSync, unlinkSync, writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
 import { createHash } from "node:crypto";
 
 // Keep in sync with wiki-cli/src/platform.ts (cannot import TS from this .mjs hook).
@@ -21,20 +22,56 @@ function detectAssetLabel(unameSM) {
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const SKILL_ROOT = process.env.CLAUDE_PLUGIN_ROOT ?? join(SCRIPT_DIR, "..");
 
+const optedOut = ["DO_NOT_TRACK", "DISABLE_TELEMETRY"].some(
+  (k) => process.env[k] && process.env[k] !== "0"
+) || process.env.YMIR_REPORT === "off";
+
+/**
+ * Fail the install, leaving a record the CLI can file later.
+ *
+ * A failure here is invisible to the wiki CLI — the binary it would have
+ * reported through is the very thing that did not install. So the record is
+ * appended as JSONL and completed on the next `wiki` run, which keeps the whole
+ * reporting pipeline (redaction, fingerprinting, dedup) in one place instead of
+ * being half-copied into a hook that cannot import it.
+ */
+function bail(errorName, message) {
+  process.stderr.write(`[ymir] ${message}\n`);
+
+  if (!optedOut) {
+    try {
+      const dir = join(process.env.YMIR_HOME ?? join(homedir(), ".ymir"), "reports", "incoming");
+      mkdirSync(dir, { recursive: true });
+      appendFileSync(
+        join(dir, "hooks.jsonl"),
+        JSON.stringify({
+          kind: "hook",
+          command: "ensure-wiki-binary",
+          errorName,
+          message,
+          version: typeof pluginVersion === "string" ? pluginVersion : "unknown",
+          platform: typeof label === "string" ? label : "unknown",
+        }) + "\n"
+      );
+    } catch { /* A hook must never fail because reporting failed. */ }
+  }
+
+  process.exit(2);
+}
+
 let pluginVersion;
+let label;
 try {
   const manifest = JSON.parse(
     readFileSync(join(SKILL_ROOT, ".claude-plugin/plugin.json"), "utf8")
   );
   pluginVersion = manifest.version;
 } catch (e) {
-  process.stderr.write(`[ymir] Cannot read plugin.json: ${e.message}\n`);
-  process.exit(2);
+  bail("ManifestUnreadable", `Cannot read plugin.json: ${e.message}`);
 }
 
 if (typeof pluginVersion !== "string" || !/^\d+\.\d+\.\d+/.test(pluginVersion)) {
-  process.stderr.write(`[ymir] Invalid plugin version: ${JSON.stringify(pluginVersion)}\n`);
-  process.exit(2);
+  bail("InvalidVersion", `Invalid plugin version: ${JSON.stringify(pluginVersion)}`);
 }
 
 const binDir    = join(SKILL_ROOT, "wiki-cli/bin");
@@ -45,13 +82,11 @@ if (existsSync(binPath) && existsSync(stampPath)) {
   if (readFileSync(stampPath, "utf8").trim() === pluginVersion) process.exit(0);
 }
 
-let label;
 try {
   const uname = execSync("uname -sm", { encoding: "utf8" });
   label = detectAssetLabel(uname);
 } catch (e) {
-  process.stderr.write(`[ymir] Platform detection failed: ${e.message}\n`);
-  process.exit(2);
+  bail("UnsupportedPlatform", `Platform detection failed: ${e.message}`);
 }
 
 const base     = `https://github.com/muitneliss/ymir/releases/download/ymir-v${pluginVersion}`;
@@ -71,15 +106,13 @@ const cleanupTmp = () => {
 const dlBin = spawnSync("curl", ["-fsSL", "--output", tmpBin, assetUrl], { stdio: "inherit" });
 if (dlBin.status !== 0) {
   cleanupTmp();
-  process.stderr.write(`[ymir] Failed to download wiki binary: ${assetUrl}\n`);
-  process.exit(2);
+  bail("DownloadFailed", `Failed to download wiki binary: ${assetUrl}`);
 }
 
 const dlSums = spawnSync("curl", ["-fsSL", "--output", tmpSums, sumsUrl], { stdio: "inherit" });
 if (dlSums.status !== 0) {
   cleanupTmp();
-  process.stderr.write(`[ymir] Failed to download SHA256SUMS: ${sumsUrl}\n`);
-  process.exit(2);
+  bail("ChecksumDownloadFailed", `Failed to download SHA256SUMS: ${sumsUrl}`);
 }
 
 const sumsText     = readFileSync(tmpSums, "utf8");
@@ -89,17 +122,16 @@ const expectedLine = sumsText.split("\n").find((l) => {
 });
 if (!expectedLine) {
   cleanupTmp();
-  process.stderr.write(`[ymir] No sha256 entry for wiki-${label} in SHA256SUMS.txt\n`);
-  process.exit(2);
+  bail("ChecksumMissing", `No sha256 entry for wiki-${label} in SHA256SUMS.txt`);
 }
 const expectedHash = expectedLine.trim().split(/\s+/)[0];
 const actualHash   = createHash("sha256").update(readFileSync(tmpBin)).digest("hex");
 if (actualHash !== expectedHash) {
   cleanupTmp();
-  process.stderr.write(
-    `[ymir] SHA256 mismatch for wiki-${label}:\n  expected ${expectedHash}\n  got      ${actualHash}\n`
+  bail(
+    "ChecksumMismatch",
+    `SHA256 mismatch for wiki-${label}:\n  expected ${expectedHash}\n  got      ${actualHash}`
   );
-  process.exit(2);
 }
 
 renameSync(tmpBin, binPath);

--- a/wiki-cli/src/cli.ts
+++ b/wiki-cli/src/cli.ts
@@ -20,12 +20,29 @@ import { NoteType } from "./schema.js";
 import { join, resolve } from "node:path";
 import { fileProvenance } from "./provenance.js";
 import { reindex } from "./reindex.js";
+import { runReport } from "./commands/report.js";
+import { capture, draftFromError, maybeFlush, REPORT_HINT } from "./report.js";
+import { loadConfig, reportHome } from "./report/store.js";
+import { readFileSync as readVersionFile } from "node:fs";
+import { dirname } from "node:path";
 
 const today = () => new Date().toISOString().slice(0, 10);
 const readStdin = () => readFileSync(0, "utf8");
 
+function version(): string {
+  try {
+    return readVersionFile(join(dirname(process.execPath), ".version"), "utf8").trim() || "dev";
+  } catch {
+    return "dev";
+  }
+}
+
 const program = new Command();
-program.name("wiki").description("Ymir wiki CLI").option("--root <dir>", "wiki root", "wiki");
+program
+  .name("wiki")
+  .description("Ymir wiki CLI")
+  .version(version())
+  .option("--root <dir>", "wiki root", "wiki");
 
 program
   .command("ingest")
@@ -88,7 +105,16 @@ program
   .option("--no-reindex", "skip qmd reindex after write")
   .action(async (opts: { type: string; name: string; reindex: boolean }) => {
     const root = program.opts<{ root: string }>().root;
-    const type = NoteType.parse(opts.type);
+
+    const parsed = NoteType.safeParse(opts.type);
+    if (!parsed.success) {
+      process.stderr.write(
+        `error: --type must be one of ${NoteType.options.join("|")} (got "${opts.type}")\n`,
+      );
+      process.exit(1);
+    }
+
+    const type = parsed.data;
     const path = await runNote({ root, type, name: opts.name, body: readStdin(), today: today(), noReindex: !opts.reindex });
     process.stdout.write(`wrote ${path}\n`);
   });
@@ -279,4 +305,61 @@ program
     }
   });
 
-program.parseAsync();
+program
+  .command("report")
+  .description("review, file, or disable Ymir self-reports")
+  .option("--yes", "consent and file pending reports now", false)
+  .option("--flush", "file pending reports if already consented; silent otherwise", false)
+  .option("--skill", "record a skill-flow failure", false)
+  .option("--title <title>", "short summary (with --skill)")
+  .option("--detail <detail>", "what happened (with --skill)")
+  .option("--feedback <text>", "record an improvement idea")
+  .option("--off", "opt out and discard anything captured", false)
+  .action((opts: {
+    yes: boolean;
+    flush: boolean;
+    skill: boolean;
+    title?: string;
+    detail?: string;
+    feedback?: string;
+    off: boolean;
+  }) => {
+    const { text, exitCode } = runReport({
+      yes: opts.yes,
+      flush: opts.flush,
+      off: opts.off,
+      feedback: opts.feedback,
+      skill: opts.skill ? { title: opts.title ?? "", detail: opts.detail ?? "" } : undefined,
+    });
+    process.stdout.write(text);
+    if (exitCode !== 0) process.exit(exitCode);
+  });
+
+/**
+ * The one place a command's failure becomes a user-facing message.
+ *
+ * Before this existed, `program.parseAsync()` ran unattended: anything an async
+ * action threw escaped as an unhandled rejection and reached the user as a raw
+ * V8 dump. The compiled binary makes that worse, not better — it prints no stack
+ * frames at all, so the dump is noise with nothing to act on.
+ *
+ * Only genuine exceptions are captured. The inline `process.exit(1)` paths — a
+ * bad flag, a failing `check` — are the CLI working correctly, and reporting
+ * them would bury real bugs under everyone's typos.
+ */
+async function main(): Promise<void> {
+  maybeFlush();
+
+  try {
+    await program.parseAsync();
+  } catch (e) {
+    const command = program.args[0] ? `wiki ${program.args[0]}` : "wiki";
+    process.stderr.write(`error: ${(e as Error)?.message ?? String(e)}\n`);
+
+    if (capture(draftFromError(command, e)) !== null) process.stderr.write(`${REPORT_HINT}\n`);
+
+    process.exit(1);
+  }
+}
+
+void main();

--- a/wiki-cli/src/cli.ts
+++ b/wiki-cli/src/cli.ts
@@ -22,7 +22,7 @@ import { fileProvenance } from "./provenance.js";
 import { reindex } from "./reindex.js";
 import { runReport } from "./commands/report.js";
 import { capture, draftFromError, maybeFlush, REPORT_HINT } from "./report.js";
-import { loadConfig, reportHome } from "./report/store.js";
+import { Rejection } from "./rejection.js";
 import { readFileSync as readVersionFile } from "node:fs";
 import { dirname } from "node:path";
 
@@ -343,9 +343,10 @@ program
  * V8 dump. The compiled binary makes that worse, not better — it prints no stack
  * frames at all, so the dump is noise with nothing to act on.
  *
- * Only genuine exceptions are captured. The inline `process.exit(1)` paths — a
- * bad flag, a failing `check` — are the CLI working correctly, and reporting
- * them would bury real bugs under everyone's typos.
+ * Only genuine exceptions are captured. The inline `process.exit(1)` paths and
+ * every `Rejection` — a bad flag, a slug collision, a broken link — are the CLI
+ * working correctly, and reporting them would bury real bugs under everyone's
+ * typos.
  */
 async function main(): Promise<void> {
   maybeFlush();
@@ -353,10 +354,12 @@ async function main(): Promise<void> {
   try {
     await program.parseAsync();
   } catch (e) {
-    const command = program.args[0] ? `wiki ${program.args[0]}` : "wiki";
     process.stderr.write(`error: ${(e as Error)?.message ?? String(e)}\n`);
 
-    if (capture(draftFromError(command, e)) !== null) process.stderr.write(`${REPORT_HINT}\n`);
+    if (!(e instanceof Rejection)) {
+      const command = program.args[0] ? `wiki ${program.args[0]}` : "wiki";
+      if (capture(draftFromError(command, e)) !== null) process.stderr.write(`${REPORT_HINT}\n`);
+    }
 
     process.exit(1);
   }

--- a/wiki-cli/src/commands/help.ts
+++ b/wiki-cli/src/commands/help.ts
@@ -46,6 +46,19 @@ Commands:
                                       --verbatim searches the text exactly as typed.
                                       --chunks returns matching passages instead of
                                       whole files.
+  report [--yes|--off|--flush]        Review and file Ymir self-reports. With no flags it
+                                      prints the exact issue text that would be posted and
+                                      sends nothing. --yes opts in and files them; after
+                                      that they are filed automatically. --off opts out and
+                                      discards anything captured.
+                                      --feedback "<text>" records an improvement idea;
+                                      --skill --title <t> --detail <d> records a skill-flow
+                                      failure the CLI could not see itself.
+                                      Reports carry the command, error, version and platform
+                                      only — paths, hostnames, credentials and identities are
+                                      stripped. Nothing is sent until you opt in. Disable
+                                      entirely with DO_NOT_TRACK=1, DISABLE_TELEMETRY=1, or
+                                      YMIR_REPORT=off; retarget with YMIR_REPORT_REPO.
   help                                Show this text.
 
 Page conventions:

--- a/wiki-cli/src/commands/ingest.ts
+++ b/wiki-cli/src/commands/ingest.ts
@@ -7,6 +7,7 @@ import { buildIndex } from "../index-build.js";
 import { appendLog } from "../wikilog.js";
 import { validateWiki } from "../validate.js";
 import { reindex, type ReindexRunner } from "../reindex.js";
+import { Rejection } from "../rejection.js";
 
 export interface IngestInput {
   root: string;
@@ -34,7 +35,7 @@ export async function runIngest(i: IngestInput): Promise<string> {
   if (existsSync(path)) {
     const existingTitle = (parseFrontmatter(readPage(path)).data as { title?: string }).title;
     if (existingTitle !== i.title) {
-      throw new Error(
+      throw new Rejection(
         `ingest rejected: slug collision — "${path}" already holds "${existingTitle}", cannot overwrite with "${i.title}"`,
       );
     }
@@ -46,7 +47,7 @@ export async function runIngest(i: IngestInput): Promise<string> {
   if (!result.ok) {
     if (prev === null) rmSync(path);
     else writePage(path, prev);
-    throw new Error(`ingest rejected:\n${result.errors.join("\n")}`);
+    throw new Rejection(`ingest rejected:\n${result.errors.join("\n")}`);
   }
 
   writePage(wikiPaths(i.root).index, buildIndex(i.root));

--- a/wiki-cli/src/commands/note.ts
+++ b/wiki-cli/src/commands/note.ts
@@ -8,6 +8,7 @@ import { appendLog } from "../wikilog.js";
 import { validateWiki } from "../validate.js";
 import { reindex, type ReindexRunner } from "../reindex.js";
 import type { NoteTypeT } from "../schema.js";
+import { Rejection } from "../rejection.js";
 
 export interface NoteInput {
   root: string; type: NoteTypeT; name: string; body: string; today: string;
@@ -23,7 +24,7 @@ export async function runNote(i: NoteInput): Promise<string> {
     const existing = parseFrontmatter(readPage(path));
     const data = existing.data as { title?: string; source_count?: number };
     if (data.title !== i.name) {
-      throw new Error(
+      throw new Rejection(
         `note rejected: slug collision — "${path}" already holds "${data.title}", cannot overwrite with "${i.name}"`,
       );
     }
@@ -41,7 +42,7 @@ export async function runNote(i: NoteInput): Promise<string> {
   if (!result.ok) {
     if (prev === null) rmSync(path);
     else writePage(path, prev);
-    throw new Error(`note rejected:\n${result.errors.join("\n")}`);
+    throw new Rejection(`note rejected:\n${result.errors.join("\n")}`);
   }
 
   writePage(wikiPaths(i.root).index, buildIndex(i.root));

--- a/wiki-cli/src/commands/remove.ts
+++ b/wiki-cli/src/commands/remove.ts
@@ -6,6 +6,7 @@ import { buildIndex } from "../index-build.js";
 import { appendLog } from "../wikilog.js";
 import { parseFrontmatter } from "../frontmatter.js";
 import { reindex, type ReindexRunner } from "../reindex.js";
+import { Rejection } from "../rejection.js";
 
 export interface InboundLink {
   from: string;
@@ -59,7 +60,7 @@ function scanInboundLinks(root: string, title: string, excludePath: string): Inb
 
 export function runRemove(i: RemoveInput): RemoveResult {
   const path = findPage(i.root, i.title);
-  if (!path) throw new Error(`remove rejected: "${i.title}" not found`);
+  if (!path) throw new Rejection(`remove rejected: "${i.title}" not found`);
 
   const inboundLinks = scanInboundLinks(i.root, i.title, path);
 
@@ -67,7 +68,7 @@ export function runRemove(i: RemoveInput): RemoveResult {
 
   if (inboundLinks.length > 0) {
     const detail = inboundLinks.map((l) => `  ${l.from}: ${l.link}`).join("\n");
-    throw new Error(`remove rejected: inbound link(s) would break — remove or update them first:\n${detail}`);
+    throw new Rejection(`remove rejected: inbound link(s) would break — remove or update them first:\n${detail}`);
   }
 
   rmSync(path);

--- a/wiki-cli/src/commands/rename.ts
+++ b/wiki-cli/src/commands/rename.ts
@@ -7,6 +7,7 @@ import { appendLog } from "../wikilog.js";
 import { parseFrontmatter, stringifyFrontmatter } from "../frontmatter.js";
 import { validateWiki } from "../validate.js";
 import { reindex, type ReindexRunner } from "../reindex.js";
+import { Rejection } from "../rejection.js";
 
 export interface RenameInput {
   root: string;
@@ -61,7 +62,7 @@ function rewriteLinks(content: string, oldSlug: string, newTitle: string): { upd
 
 export async function runRename(i: RenameInput): Promise<RenameResult> {
   const found = findPage(i.root, i.oldTitle);
-  if (!found) throw new Error(`rename rejected: "${i.oldTitle}" not found`);
+  if (!found) throw new Rejection(`rename rejected: "${i.oldTitle}" not found`);
 
   const targetPath = newPath(i.root, found.sub, i.newTitle);
   const newSlug = slugify(i.newTitle);
@@ -69,7 +70,7 @@ export async function runRename(i: RenameInput): Promise<RenameResult> {
 
   if (newSlug !== oldSlug && existsSync(targetPath)) {
     const existingTitle = (parseFrontmatter(readPage(targetPath)).data as { title?: string }).title;
-    throw new Error(
+    throw new Rejection(
       `rename rejected: slug collision — "${targetPath}" already holds "${existingTitle}"`,
     );
   }
@@ -127,7 +128,7 @@ export async function runRename(i: RenameInput): Promise<RenameResult> {
   const result = validateWiki(i.root);
   if (!result.ok) {
     restore();
-    throw new Error(`rename rejected:\n${result.errors.join("\n")}`);
+    throw new Rejection(`rename rejected:\n${result.errors.join("\n")}`);
   }
 
   writePage(wikiPaths(i.root).index, buildIndex(i.root));

--- a/wiki-cli/src/commands/report.ts
+++ b/wiki-cli/src/commands/report.ts
@@ -1,0 +1,146 @@
+import { capture, flush } from "../report.js";
+import { renderBody, renderTitle, type GhRunner } from "../report/github.js";
+import { clearSpool, loadConfig, pending, reportHome, saveConfig, type Env } from "../report/store.js";
+
+export interface ReportInput {
+  env?: Env;
+  run?: GhRunner;
+  /** Consent and send now — the one-time opt-in. */
+  yes?: boolean;
+  /** Send if already consented; say nothing otherwise. */
+  flush?: boolean;
+  skill?: { title: string; detail: string };
+  feedback?: string;
+  off?: boolean;
+}
+
+export interface ReportOutput {
+  text: string;
+  exitCode: number;
+}
+
+/**
+ * `wiki report` — review, file, and opt in or out of self-reporting.
+ *
+ * With no flags it is a preview, never a send. A user's first contact with this
+ * feature is a crash hint, and the honest thing to show them next is the exact
+ * text that would become a public issue, before anything leaves the machine.
+ */
+export function runReport(input: ReportInput): ReportOutput {
+  const env = input.env ?? process.env;
+  const root = reportHome(env);
+
+  if (input.off) return optOut(root);
+  if (input.skill) return captureSkill(root, env, input.skill);
+  if (input.feedback !== undefined) return captureFeedback(root, env, input.feedback);
+  if (input.flush) return flushQuietly(input);
+
+  return input.yes ? consentAndSend(root, env, input) : preview(root, env);
+}
+
+function optOut(root: string): ReportOutput {
+  saveConfig(root, { mode: "off" });
+  clearSpool(root);
+  return {
+    text: "self-report is off. Nothing further will be captured or sent.\nRe-enable with `wiki report --yes`.\n",
+    exitCode: 0,
+  };
+}
+
+function captureSkill(root: string, env: Env, skill: { title: string; detail: string }): ReportOutput {
+  if (skill.title.trim() === "") {
+    return { text: "error: --title is required with --skill\n", exitCode: 1 };
+  }
+
+  capture(
+    {
+      kind: "skill",
+      command: "ymir skill",
+      errorName: "SkillFlowFailure",
+      message: `${skill.title.trim()}\n\n${skill.detail.trim()}`,
+    },
+    env,
+  );
+
+  return { text: capturedText(root, env), exitCode: 0 };
+}
+
+function captureFeedback(root: string, env: Env, feedback: string): ReportOutput {
+  if (feedback.trim() === "") {
+    return { text: "error: --feedback needs some text\n", exitCode: 1 };
+  }
+
+  capture(
+    { kind: "feedback", command: "ymir feedback", errorName: "Feedback", message: feedback.trim() },
+    env,
+  );
+
+  return { text: capturedText(root, env), exitCode: 0 };
+}
+
+/** Whether the note just captured will go out on its own, or needs a nudge. */
+function capturedText(root: string, env: Env): string {
+  const consented = loadConfig(root, env).mode === "auto";
+  return consented
+    ? "captured — it will be filed on the next run.\n"
+    : "captured locally. Review it with `wiki report`, then send with `wiki report --yes`.\n";
+}
+
+/** The opportunistic and hook-driven path: succeed silently or say nothing. */
+function flushQuietly(input: ReportInput): ReportOutput {
+  flush({ env: input.env, run: input.run });
+  return { text: "", exitCode: 0 };
+}
+
+function preview(root: string, env: Env): ReportOutput {
+  const config = loadConfig(root, env);
+  const reports = pending(root);
+
+  if (reports.length === 0) return { text: "nothing to report — no failures captured.\n", exitCode: 0 };
+
+  const lines = [
+    `${reports.length} report(s) pending, destined for ${config.repo}:`,
+    "",
+  ];
+
+  for (const report of reports) {
+    lines.push(`── ${renderTitle(report)}`, "", renderBody(report), "");
+  }
+
+  lines.push(
+    config.mode === "auto"
+      ? "You have opted in — these are filed automatically. `wiki report --off` to stop."
+      : "Nothing has been sent. `wiki report --yes` files these and opts you in; `wiki report --off` discards them.",
+  );
+
+  return { text: lines.join("\n") + "\n", exitCode: 0 };
+}
+
+function consentAndSend(root: string, env: Env, input: ReportInput): ReportOutput {
+  if (loadConfig(root, env).mode === "off") {
+    return {
+      text: "self-report is opted out via DO_NOT_TRACK, DISABLE_TELEMETRY, or YMIR_REPORT=off.\nUnset it to send reports.\n",
+      exitCode: 0,
+    };
+  }
+
+  saveConfig(root, { mode: "auto" });
+
+  const summary = flush({ env, run: input.run });
+  if (summary.results.length === 0) return { text: "opted in. Nothing pending to send.\n", exitCode: 0 };
+
+  const config = loadConfig(root, env);
+  const lines: string[] = [];
+
+  for (const { result } of summary.results) {
+    if (result.outcome === "created") lines.push(`filed https://github.com/${config.repo}/issues/${result.issue}`);
+    else if (result.outcome === "commented") {
+      lines.push(`added to https://github.com/${config.repo}/issues/${result.issue}`);
+    } else if (result.outcome === "fallback-url") {
+      lines.push("gh is unavailable — open this to file it yourself:", result.url ?? "");
+    } else lines.push("could not reach GitHub — kept locally, will retry.");
+  }
+
+  lines.push("", "Opted in: future reports are filed automatically. `wiki report --off` to stop.");
+  return { text: lines.join("\n") + "\n", exitCode: 0 };
+}

--- a/wiki-cli/src/rejection.ts
+++ b/wiki-cli/src/rejection.ts
@@ -1,0 +1,16 @@
+/**
+ * A failure the CLI predicted, explained, and refused on purpose — a slug
+ * collision, a broken `[[link]]`, a page that does not exist.
+ *
+ * The distinction from an ordinary `Error` is what keeps self-reporting useful.
+ * A rejection means the CLI worked: it validated input and said no. Filing those
+ * upstream would bury the genuine crashes under everyone's typos, so the error
+ * boundary prints a rejection and stops, and reports only what it did not
+ * predict.
+ *
+ * This replaces the older `"<command> rejected: ..."` message-prefix convention,
+ * which callers could only detect by matching on the text.
+ */
+export class Rejection extends Error {
+  override readonly name = "Rejection";
+}

--- a/wiki-cli/src/report.ts
+++ b/wiki-cli/src/report.ts
@@ -1,0 +1,175 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fingerprint, type Report, type ReportDraft } from "./report/model.js";
+import { redact, truncate } from "./report/redact.js";
+import { postReport, type GhRunner, type PostResult } from "./report/github.js";
+import {
+  loadConfig,
+  pending,
+  postedIssue,
+  reportHome,
+  resolvePosted,
+  saveConfig,
+  spool,
+  type Env,
+} from "./report/store.js";
+
+/**
+ * Ymir's self-report: turn a failure on a user's machine into an issue the
+ * maintainers can act on.
+ *
+ * The split that matters is capture from delivery. Capture runs on the error
+ * path and only ever touches the local disk — a crashing CLI must not also wait
+ * on a network call. Delivery happens later, from `wiki report` or the
+ * opportunistic flush, where being slow is merely slow.
+ */
+
+export const REPORT_HINT =
+  "[ymir] That looks like a bug in Ymir. Run `wiki report` to review it and file it upstream (`--off` to disable).";
+
+/** How long the opportunistic flush waits before trying again. */
+const FLUSH_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+const MESSAGE_LIMIT = 4_000;
+const STACK_LIMIT = 4_000;
+
+export interface FlushOptions {
+  env?: Env;
+  run?: GhRunner;
+}
+
+export interface FlushSummary {
+  posted: number;
+  results: { report: Report; result: PostResult }[];
+}
+
+/**
+ * The Ymir version that produced this report.
+ *
+ * Read from the `.version` stamp `ensure-wiki-binary.mjs` writes beside the
+ * executable, so the version a report claims is the one that was actually
+ * installed — the compiled binary carries no version of its own, and inventing a
+ * second source for it would just create something new to drift.
+ */
+function resolveVersion(): string {
+  try {
+    return readFileSync(join(dirname(process.execPath), ".version"), "utf8").trim() || "dev";
+  } catch {
+    return "dev";
+  }
+}
+
+export function draftFromError(command: string, error: unknown, flags?: string[]): ReportDraft {
+  const isError = error instanceof Error;
+  return {
+    kind: "cli-error",
+    command,
+    errorName: isError ? error.name : "Error",
+    message: isError ? error.message : String(error),
+    stack: isError ? error.stack : undefined,
+    flags,
+  };
+}
+
+/**
+ * Record a report locally.
+ *
+ * Redaction happens here, before the fingerprint is computed, and that ordering
+ * is load-bearing twice over. It keeps the on-disk spool safe to read, and it
+ * makes one bug fingerprint identically on every machine — fingerprinting the
+ * raw message would fold each user's home directory into the identity, so the
+ * same crash would arrive as a fresh issue from every person who hit it.
+ */
+export function capture(draft: ReportDraft, env: Env = process.env): Report | null {
+  try {
+    const root = reportHome(env);
+    if (loadConfig(root, env).mode === "off") return null;
+
+    const ctx = { cwd: env.YMIR_CWD ?? process.cwd() };
+    const clean: ReportDraft = {
+      ...draft,
+      message: truncate(redact(draft.message, ctx), MESSAGE_LIMIT, 40),
+      stack: draft.stack ? truncate(redact(draft.stack, ctx), STACK_LIMIT, 12) : undefined,
+    };
+
+    const now = new Date().toISOString();
+    const report: Report = {
+      ...clean,
+      schema: 1,
+      fingerprint: fingerprint(clean),
+      version: resolveVersion(),
+      platform: `${process.platform}-${process.arch}`,
+      firstSeen: now,
+      lastSeen: now,
+      occurrences: 1,
+    };
+
+    spool(root, report);
+    return report;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Deliver every pending report.
+ *
+ * A report is dropped only once it is genuinely filed. A failed post — or a
+ * fallback URL, which nobody has opened yet — leaves it spooled so the next
+ * flush tries again.
+ */
+export function flush(options: FlushOptions = {}): FlushSummary {
+  const env = options.env ?? process.env;
+  const root = reportHome(env);
+  const config = loadConfig(root, env);
+
+  const summary: FlushSummary = { posted: 0, results: [] };
+  if (config.mode !== "auto") return summary;
+
+  for (const report of pending(root)) {
+    const result = postReport(report, {
+      repo: config.repo,
+      run: options.run,
+      postedIssue: (fp) => postedIssue(root, fp),
+    });
+
+    summary.results.push({ report, result });
+
+    if ((result.outcome === "created" || result.outcome === "commented") && result.issue !== undefined) {
+      resolvePosted(root, report.fingerprint, result.issue);
+      summary.posted++;
+    }
+  }
+
+  return summary;
+}
+
+/**
+ * Deliver pending reports from an ordinary command, if it is cheap and welcome.
+ *
+ * This is what makes reporting automatic without a background process or a
+ * Claude-Code-only hook — the latter would never fire for `skills add` installs
+ * on other agents. The gates are ordered cheapest first, so the overwhelmingly
+ * common case (nothing to send) costs a single directory read, and it can never
+ * change the host command's output or exit code.
+ */
+export function maybeFlush(options: FlushOptions = {}): void {
+  try {
+    const env = options.env ?? process.env;
+    const root = reportHome(env);
+
+    const config = loadConfig(root, env);
+    if (config.mode !== "auto") return;
+    if (pending(root).length === 0) return;
+
+    if (config.lastFlushAt) {
+      const since = Date.now() - Date.parse(config.lastFlushAt);
+      if (Number.isFinite(since) && since < FLUSH_INTERVAL_MS) return;
+    }
+
+    saveConfig(root, { lastFlushAt: new Date().toISOString() });
+    flush(options);
+  } catch {
+    /* Reporting must never be why a working command failed. */
+  }
+}

--- a/wiki-cli/src/report/github.ts
+++ b/wiki-cli/src/report/github.ts
@@ -1,0 +1,213 @@
+import { spawnSync } from "node:child_process";
+import { redact, truncate } from "./redact.js";
+import type { Report } from "./model.js";
+
+/**
+ * Delivery of a report to a GitHub issue tracker.
+ *
+ * Ymir runs on other people's machines, so it has no credentials of its own and
+ * must not ship any. It borrows the user's `gh` login instead: the issue is
+ * filed by them, visibly, with nothing to leak if the binary is inspected. When
+ * `gh` is missing or logged out there is no silent failure either — the report
+ * comes back as a prefilled URL the user can open.
+ *
+ * Like `reindex.ts`, every path here degrades instead of throwing: a report that
+ * cannot be delivered is not worth failing a command over.
+ */
+
+export interface RunnerResult {
+  status: number | null;
+  stdout: string;
+}
+
+export type GhRunner = (args: string[]) => RunnerResult;
+
+export type PostOutcome = "created" | "commented" | "fallback-url" | "failed";
+
+export interface PostResult {
+  outcome: PostOutcome;
+  issue?: number;
+  url?: string;
+}
+
+export interface PostOptions {
+  repo: string;
+  run?: GhRunner;
+  /** Locally known fingerprint → issue mapping, consulted before any search. */
+  postedIssue: (fingerprint: string) => number | null;
+}
+
+const LABEL = "self-report";
+const BODY_LIMIT = 12_000;
+const MESSAGE_LIMIT = 2_000;
+const STACK_LIMIT = 2_000;
+
+/** Browsers and servers both start refusing somewhere past 8k. */
+const URL_LIMIT = 8_000;
+
+const KIND_HEADING: Record<Report["kind"], string> = {
+  "cli-error": "CLI error",
+  skill: "Skill-flow failure",
+  hook: "Plugin hook failure",
+  feedback: "Feedback",
+};
+
+const defaultRunner: GhRunner = (args) => {
+  const result = spawnSync("gh", args, { stdio: "pipe", encoding: "utf8", timeout: 20_000 });
+  return { status: result.status, stdout: `${result.stdout ?? ""}${result.stderr ?? ""}` };
+};
+
+export function renderTitle(report: Report): string {
+  const summary = redact(report.message).split("\n")[0]!.trim();
+  const prefix = report.kind === "feedback" ? "feedback" : `${report.command}: ${report.errorName}`;
+  return truncate(`[self-report] ${prefix} — ${summary}`, 120);
+}
+
+/**
+ * The issue body.
+ *
+ * Redacts a second time even though the report was redacted when captured: this
+ * is the last point before the text becomes public and permanent, and the cost
+ * of the duplicate pass is nothing next to the cost of being wrong once.
+ */
+export function renderBody(report: Report): string {
+  const message = truncate(redact(report.message), MESSAGE_LIMIT, 40);
+  const stack = report.stack ? truncate(redact(report.stack), STACK_LIMIT, 12) : null;
+
+  const lines = [
+    `**${KIND_HEADING[report.kind]}** — filed automatically by Ymir's self-report.`,
+    "",
+    "| | |",
+    "|---|---|",
+    `| Command | \`${report.command}\` |`,
+    `| Error | \`${report.errorName}\` |`,
+    `| Ymir version | \`${report.version}\` |`,
+    `| Platform | \`${report.platform}\` |`,
+    `| Occurrences | ${report.occurrences} |`,
+    `| First seen | ${report.firstSeen} |`,
+    `| Last seen | ${report.lastSeen} |`,
+    "",
+    "### Message",
+    "",
+    "```",
+    message,
+    "```",
+  ];
+
+  if (report.flags?.length) {
+    lines.push("", `### Flags`, "", report.flags.map((f) => `\`${f}\``).join(", "));
+  }
+
+  if (stack) lines.push("", "### Stack", "", "```", stack, "```");
+
+  lines.push(
+    "",
+    "---",
+    "",
+    `Fingerprint \`${report.fingerprint}\` — recurrences are added as comments here.`,
+    "Paths, hostnames, credentials and identities were stripped before sending.",
+    "Opt out with `wiki report --off`, `YMIR_REPORT=off`, or `DO_NOT_TRACK=1`.",
+  );
+
+  return truncate(lines.join("\n"), BODY_LIMIT);
+}
+
+export function fallbackUrl(report: Report, repo: string): string {
+  const title = encodeURIComponent(renderTitle(report));
+  const base = `https://github.com/${repo}/issues/new?labels=${LABEL}&title=${title}&body=`;
+
+  let budget = URL_LIMIT - base.length;
+  let body = renderBody(report);
+  let encoded = encodeURIComponent(body);
+
+  // Percent-encoding expands unpredictably, so shrink the source until it fits.
+  while (encoded.length > budget && body.length > 200) {
+    body = truncate(body, Math.floor(body.length * 0.7));
+    encoded = encodeURIComponent(body);
+  }
+
+  return base + encoded.slice(0, Math.max(0, budget));
+}
+
+function ghAvailable(run: GhRunner): boolean {
+  const result = run(["auth", "status"]);
+  return result.status === 0;
+}
+
+/** An issue for this fingerprint filed from some other machine. */
+function findRemote(run: GhRunner, repo: string, fingerprint: string): number | null {
+  const result = run([
+    "issue",
+    "list",
+    "--repo",
+    repo,
+    "--search",
+    `${fingerprint} in:body`,
+    "--state",
+    "all",
+    "--limit",
+    "1",
+    "--json",
+    "number,state",
+  ]);
+  if (result.status !== 0) return null;
+
+  try {
+    const rows = JSON.parse(result.stdout) as { number: number }[];
+    return rows[0]?.number ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function issueNumberFrom(stdout: string): number | null {
+  const match = stdout.trim().match(/\/issues\/(\d+)\s*$/m);
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * File a new issue, retrying unlabelled if the destination has no `self-report`
+ * label — a fork will not, and losing the label is a far better outcome than
+ * losing the report.
+ */
+function createIssue(run: GhRunner, repo: string, report: Report): PostResult {
+  const base = ["issue", "create", "--repo", repo, "--title", renderTitle(report), "--body", renderBody(report)];
+
+  let result = run([...base, "--label", LABEL]);
+  if (result.status !== 0 && /label/i.test(result.stdout)) result = run(base);
+
+  if (result.status !== 0) return { outcome: "failed" };
+
+  const issue = issueNumberFrom(result.stdout);
+  return issue === null ? { outcome: "failed" } : { outcome: "created", issue };
+}
+
+function commentRecurrence(run: GhRunner, repo: string, report: Report, issue: number): PostResult {
+  const body = [
+    `Seen again on Ymir \`${report.version}\` (\`${report.platform}\`) — ${report.occurrences} occurrence(s) as of ${report.lastSeen}.`,
+    "",
+    "```",
+    truncate(redact(report.message), MESSAGE_LIMIT, 20),
+    "```",
+  ].join("\n");
+
+  const result = run(["issue", "comment", String(issue), "--repo", repo, "--body", body]);
+  return result.status === 0 ? { outcome: "commented", issue } : { outcome: "failed", issue };
+}
+
+export function postReport(report: Report, options: PostOptions): PostResult {
+  const run = options.run ?? defaultRunner;
+
+  try {
+    if (!ghAvailable(run)) {
+      return { outcome: "fallback-url", url: fallbackUrl(report, options.repo) };
+    }
+
+    const known = options.postedIssue(report.fingerprint) ?? findRemote(run, options.repo, report.fingerprint);
+    if (known !== null) return commentRecurrence(run, options.repo, report, known);
+
+    return createIssue(run, options.repo, report);
+  } catch {
+    return { outcome: "failed" };
+  }
+}

--- a/wiki-cli/src/report/model.ts
+++ b/wiki-cli/src/report/model.ts
@@ -1,0 +1,43 @@
+import { sha256Hex } from "../hash.js";
+
+export type ReportKind = "cli-error" | "skill" | "hook" | "feedback";
+
+/** What a caller knows at the moment something goes wrong. */
+export interface ReportDraft {
+  kind: ReportKind;
+  /** Subcommand only — never argument values, which carry user data. */
+  command: string;
+  errorName: string;
+  message: string;
+  stack?: string;
+  /** Flag names only, for the same reason as `command`. */
+  flags?: string[];
+}
+
+/** A draft plus the identity and environment the reporter adds. */
+export interface Report extends ReportDraft {
+  schema: 1;
+  fingerprint: string;
+  version: string;
+  platform: string;
+  firstSeen: string;
+  lastSeen: string;
+  occurrences: number;
+}
+
+/**
+ * A stable identity for "this same bug", used to merge recurrences locally and
+ * to find an already-filed issue upstream.
+ *
+ * Deliberately excludes the stack. Ymir ships as a `bun build --compile`
+ * binary, and that artifact emits no usable frames at all — a fingerprint over
+ * frames would be empty in exactly the builds real users run, while still
+ * differing between a maintainer's dev checkout and everyone else.
+ *
+ * Runs of digits collapse so that counts, line numbers and sizes ("after 3
+ * pages" vs "after 47 pages") do not split one bug across dozens of issues.
+ */
+export function fingerprint(draft: ReportDraft): string {
+  const normalized = draft.message.trim().toLowerCase().replace(/\d+/g, "N");
+  return sha256Hex([draft.kind, draft.command, draft.errorName, normalized].join("\0")).slice(0, 12);
+}

--- a/wiki-cli/src/report/redact.ts
+++ b/wiki-cli/src/report/redact.ts
@@ -1,0 +1,139 @@
+/**
+ * Reduce arbitrary error text to something safe to publish on a public issue
+ * tracker.
+ *
+ * Every report Ymir files is written from an end user's machine to
+ * `muitneliss/ymir`, where it is world-readable and effectively permanent. The
+ * threat is not a malicious payload — it is ordinary error text that happens to
+ * carry the user's name, employer, or credentials, because error messages quote
+ * whatever they were handed.
+ *
+ * So this denies by default on the three things that identify a person:
+ * filesystem paths, hostnames, and credential-shaped strings. What survives is
+ * the part that actually helps a maintainer: project-relative paths, basenames,
+ * and the shape of the failure.
+ */
+
+export interface RedactContext {
+  /** Absolute project root. Paths under it keep their relative tail. */
+  cwd?: string;
+}
+
+const REDACTED = "<redacted>";
+
+/**
+ * Hosts whose names carry no information about who is running Ymir. Everything
+ * else is replaced whole: `ci.acme-corp.internal` names an employer just as
+ * surely as a home directory names a user.
+ */
+const PUBLIC_HOSTS = new Set([
+  "github.com",
+  "api.github.com",
+  "raw.githubusercontent.com",
+  "objects.githubusercontent.com",
+  "codeload.github.com",
+]);
+
+/**
+ * Credential shapes, applied before any path or URL rule so that a token stays
+ * redacted even when it appears as a directory name or a query parameter.
+ */
+const SECRET_PATTERNS: RegExp[] = [
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
+  /\bgh[pousr]_[A-Za-z0-9]{16,}/g,
+  /\bgithub_pat_[A-Za-z0-9_]{20,}/g,
+  /\bsk-[A-Za-z0-9_-]{16,}/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\bxox[baprse]-[A-Za-z0-9-]{10,}/g,
+  /\bBearer\s+[A-Za-z0-9._~+/-]{16,}=*/gi,
+];
+
+/** `token=…`, `api_key: …` — the value is secret whatever the key is called. */
+const ASSIGNED_SECRET = /\b(token|secret|passwd|password|api[-_]?key|auth)\b(\s*[:=]\s*)("[^"]*"|'[^']*'|\S+)/gi;
+
+const EMAIL = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g;
+
+/** `git@github.com:owner/repo.git` — matched before EMAIL, which also fits it. */
+const SSH_REMOTE = /\b[A-Za-z0-9._-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}:[A-Za-z0-9._/-]+/g;
+
+const URL_PATTERN = /\bhttps?:\/\/\S+/gi;
+
+const WINDOWS_PATH = /\b[A-Za-z]:\\(?:[^\\\s"']+\\)*([^\\\s"']+)/g;
+
+/**
+ * An absolute POSIX path.
+ *
+ * The lookbehind keeps the rule from re-entering text an earlier rule already
+ * rewrote. Excluding `>` and `~` stops `<project>/src/a.ts` degrading to
+ * `<project><path>/a.ts` (which would also cost idempotence); excluding `:` and
+ * `/` stops it from eating the `//host/path` of a URL that `redactUrl` already
+ * judged safe to keep.
+ */
+const POSIX_PATH = /(?<![\w>~:/])\/(?:[^/\s"':]+\/)+([^/\s"':]+)/g;
+
+function redactUrl(url: string): string {
+  const trailing = url.match(/[).,;:]+$/)?.[0] ?? "";
+  const bare = trailing ? url.slice(0, -trailing.length) : url;
+
+  let host: string;
+  let pathname: string;
+  try {
+    const parsed = new URL(bare);
+    host = parsed.hostname;
+    pathname = parsed.pathname;
+    if (parsed.username || parsed.password) return "<url>" + trailing;
+  } catch {
+    return "<url>" + trailing;
+  }
+
+  if (!PUBLIC_HOSTS.has(host)) return "<url>" + trailing;
+  return `https://${host}${pathname}` + trailing;
+}
+
+/**
+ * Strip identifying detail from `text`.
+ *
+ * Rule order is load-bearing: credentials first (so a token buried in a path or
+ * query dies regardless of what encloses it), then structured identities, then
+ * paths last — because the path rules are the greediest and would otherwise
+ * consume text the earlier rules needed to see intact.
+ */
+export function redact(text: string, ctx: RedactContext = {}): string {
+  if (text === "") return "";
+
+  let out = text;
+
+  for (const pattern of SECRET_PATTERNS) out = out.replace(pattern, REDACTED);
+  out = out.replace(ASSIGNED_SECRET, (_m, key: string, sep: string) => `${key}${sep}${REDACTED}`);
+
+  out = out.replace(SSH_REMOTE, "<git-remote>");
+  out = out.replace(URL_PATTERN, redactUrl);
+  out = out.replace(EMAIL, "<email>");
+
+  if (ctx.cwd) {
+    const root = ctx.cwd.replace(/\/+$/, "");
+    out = out.split(root).join("<project>");
+  }
+
+  out = out.replace(WINDOWS_PATH, "<path>/$1");
+  out = out.replace(POSIX_PATH, "<path>/$1");
+
+  return out;
+}
+
+/**
+ * Bound a field's contribution to an issue body. Reports are filed
+ * unattended, so a runaway message must not turn into a megabyte comment.
+ */
+export function truncate(text: string, maxChars: number, maxLines?: number): string {
+  let out = text;
+
+  if (maxLines !== undefined) {
+    const lines = out.split("\n");
+    if (lines.length > maxLines) out = lines.slice(0, maxLines).join("\n") + "\n…";
+  }
+
+  if (out.length > maxChars) out = out.slice(0, Math.max(0, maxChars - 1)) + "…";
+
+  return out;
+}

--- a/wiki-cli/src/report/store.ts
+++ b/wiki-cli/src/report/store.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fingerprint, type Report, type ReportDraft } from "./model.js";
+import { redact } from "./redact.js";
 
 /**
  * Persistent report state, in `~/.ymir`.
@@ -177,16 +178,22 @@ function adoptIncoming(root: string): Report[] {
       }
       if (!draft.kind || !draft.command || typeof draft.message !== "string") continue;
 
-      const now = draft.lastSeen ?? new Date().toISOString();
-      adopted.push({
-        schema: 1,
+      // Hook messages quote whatever path or URL failed, and the hook has no
+      // redactor of its own — this is the first point that does.
+      const clean: ReportDraft = {
         kind: draft.kind,
         command: draft.command,
         errorName: draft.errorName ?? "Error",
-        message: draft.message,
-        stack: draft.stack,
+        message: redact(draft.message),
+        stack: draft.stack ? redact(draft.stack) : undefined,
         flags: draft.flags,
-        fingerprint: fingerprint(draft),
+      };
+
+      const now = draft.lastSeen ?? new Date().toISOString();
+      adopted.push({
+        ...clean,
+        schema: 1,
+        fingerprint: fingerprint(clean),
         version: draft.version ?? "unknown",
         platform: draft.platform ?? "unknown",
         firstSeen: draft.firstSeen ?? now,

--- a/wiki-cli/src/report/store.ts
+++ b/wiki-cli/src/report/store.ts
@@ -1,0 +1,249 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fingerprint, type Report, type ReportDraft } from "./model.js";
+
+/**
+ * Persistent report state, in `~/.ymir`.
+ *
+ * Two rules govern every function here. First, **nothing throws**: this state is
+ * touched from the CLI's error path, and a reporter that crashes while reporting
+ * a crash is worse than no reporter. Every read tolerates corruption by
+ * discarding it, and every write gives up silently. Second, state is **global,
+ * not per-project** — consent is a statement about the person, not the
+ * repository, so answering once covers every project on the machine.
+ */
+
+export type ConsentMode =
+  /** Explicit opt-out. Capture nothing, keep nothing, send nothing. */
+  | "off"
+  /** Default. Capture locally so `wiki report` has something to show; send nothing. */
+  | "unset"
+  /** Opted in. Capture and send. */
+  | "auto";
+
+export interface ReportConfig {
+  mode: ConsentMode;
+  repo: string;
+  lastFlushAt?: string;
+}
+
+export const DEFAULT_REPO = "muitneliss/ymir";
+
+/** Bounded so an unattended crash loop cannot fill a user's disk. */
+export const SPOOL_LIMIT = 50;
+
+const REPO_PATTERN = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+export type Env = Record<string, string | undefined>;
+
+export function reportHome(env: Env): string {
+  return env.YMIR_HOME ?? join(env.HOME ?? env.USERPROFILE ?? ".", ".ymir");
+}
+
+const spoolDir = (root: string): string => join(root, "reports");
+const incomingDir = (root: string): string => join(spoolDir(root), "incoming");
+const configPath = (root: string): string => join(root, "config.json");
+const postedPath = (root: string): string => join(root, "posted.json");
+
+function readJson<T>(path: string): T | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+function writeJson(path: string, value: unknown): void {
+  try {
+    mkdirSync(join(path, ".."), { recursive: true });
+    writeFileSync(path, JSON.stringify(value, null, 2) + "\n", "utf8");
+  } catch {
+    /* A machine that cannot store a report still has to run the command. */
+  }
+}
+
+/** `1` and `true` opt out; `0` must not, or the flag becomes impossible to unset. */
+function isTruthy(value: string | undefined): boolean {
+  return value !== undefined && value !== "" && value !== "0" && value.toLowerCase() !== "false";
+}
+
+/**
+ * Effective config: environment beats the stored file, and a global opt-out
+ * beats everything. `DO_NOT_TRACK` / `DISABLE_TELEMETRY` are honoured because
+ * Ymir's own README already promises them for the skills CLI, and a user who
+ * sets one does not expect a second, separate channel to keep reporting.
+ */
+export function loadConfig(root: string, env: Env): ReportConfig {
+  const stored = readJson<Partial<ReportConfig>>(configPath(root)) ?? {};
+
+  const optedOut = isTruthy(env.DO_NOT_TRACK) || isTruthy(env.DISABLE_TELEMETRY);
+  const fromEnv = env.YMIR_REPORT;
+
+  let mode: ConsentMode = stored.mode === "auto" || stored.mode === "off" ? stored.mode : "unset";
+  if (fromEnv === "off" || fromEnv === "auto" || fromEnv === "unset") mode = fromEnv;
+  if (optedOut) mode = "off";
+
+  const candidate = env.YMIR_REPORT_REPO ?? stored.repo;
+  const repo = candidate && REPO_PATTERN.test(candidate) ? candidate : DEFAULT_REPO;
+
+  return { mode, repo, lastFlushAt: stored.lastFlushAt };
+}
+
+export function saveConfig(root: string, patch: Partial<ReportConfig>): void {
+  const stored = readJson<Partial<ReportConfig>>(configPath(root)) ?? {};
+  writeJson(configPath(root), { ...stored, ...patch });
+}
+
+/**
+ * Record a report, merging it into any existing one with the same fingerprint.
+ *
+ * Merging here — rather than at post time — is what keeps a crash loop from
+ * turning into fifty issues: by the time anything is sent, one bug is already
+ * one record carrying a count.
+ */
+export function spool(root: string, report: Report): void {
+  const existing = readJson<Report>(join(spoolDir(root), `${report.fingerprint}.json`));
+
+  const merged: Report = existing
+    ? {
+        ...report,
+        firstSeen: existing.firstSeen,
+        lastSeen: report.lastSeen,
+        occurrences: existing.occurrences + report.occurrences,
+      }
+    : report;
+
+  writeJson(join(spoolDir(root), `${merged.fingerprint}.json`), merged);
+  evictOverflow(root);
+}
+
+function evictOverflow(root: string): void {
+  const all = readSpool(root);
+  if (all.length <= SPOOL_LIMIT) return;
+
+  const doomed = all.sort((a, b) => a.lastSeen.localeCompare(b.lastSeen)).slice(0, all.length - SPOOL_LIMIT);
+  for (const report of doomed) drop(root, report.fingerprint);
+}
+
+function readSpool(root: string): Report[] {
+  let names: string[];
+  try {
+    names = readdirSync(spoolDir(root));
+  } catch {
+    return [];
+  }
+
+  const out: Report[] = [];
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const report = readJson<Report>(join(spoolDir(root), name));
+    if (report?.fingerprint && report.lastSeen) out.push(report);
+  }
+  return out;
+}
+
+/**
+ * Adopt records left by the plugin hooks.
+ *
+ * A `.mjs` hook cannot import this module, and hand-copying the reporting logic
+ * into it would repeat the drift the repo already suffers between `platform.ts`
+ * and its inline copy. So hooks append one JSON object per line and the CLI
+ * completes them here — the hook's whole obligation is an append.
+ */
+function adoptIncoming(root: string): Report[] {
+  let names: string[];
+  try {
+    names = readdirSync(incomingDir(root));
+  } catch {
+    return [];
+  }
+
+  const adopted: Report[] = [];
+  for (const name of names) {
+    let lines: string[];
+    try {
+      lines = readFileSync(join(incomingDir(root), name), "utf8").split("\n");
+    } catch {
+      continue;
+    }
+
+    for (const line of lines) {
+      if (line.trim() === "") continue;
+      let draft: ReportDraft & Partial<Report>;
+      try {
+        draft = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (!draft.kind || !draft.command || typeof draft.message !== "string") continue;
+
+      const now = draft.lastSeen ?? new Date().toISOString();
+      adopted.push({
+        schema: 1,
+        kind: draft.kind,
+        command: draft.command,
+        errorName: draft.errorName ?? "Error",
+        message: draft.message,
+        stack: draft.stack,
+        flags: draft.flags,
+        fingerprint: fingerprint(draft),
+        version: draft.version ?? "unknown",
+        platform: draft.platform ?? "unknown",
+        firstSeen: draft.firstSeen ?? now,
+        lastSeen: now,
+        occurrences: draft.occurrences ?? 1,
+      });
+    }
+
+    try {
+      rmSync(join(incomingDir(root), name), { force: true });
+    } catch {
+      /* Re-adopting a record next run is harmless; the fingerprint merges it. */
+    }
+  }
+
+  for (const report of adopted) spool(root, report);
+  return adopted;
+}
+
+/** Every report waiting to be filed, including any the hooks left behind. */
+export function pending(root: string): Report[] {
+  adoptIncoming(root);
+  return readSpool(root).sort((a, b) => a.firstSeen.localeCompare(b.firstSeen));
+}
+
+function drop(root: string, fp: string): void {
+  try {
+    rmSync(join(spoolDir(root), `${fp}.json`), { force: true });
+  } catch {
+    /* Nothing useful to do — the entry will merge on the next occurrence. */
+  }
+}
+
+/**
+ * Mark a fingerprint as filed, so the next occurrence comments on the existing
+ * issue instead of opening a second one.
+ *
+ * This map — not a GitHub search — is the primary dedup. GitHub's search index
+ * trails issue creation by seconds to minutes, so a crash loop that searched
+ * would find nothing and file duplicates for as long as the lag lasted.
+ */
+export function resolvePosted(root: string, fp: string, issue: number): void {
+  const map = readJson<Record<string, number>>(postedPath(root)) ?? {};
+  map[fp] = issue;
+  writeJson(postedPath(root), map);
+  drop(root, fp);
+}
+
+export function postedIssue(root: string, fp: string): number | null {
+  const map = readJson<Record<string, number>>(postedPath(root)) ?? {};
+  return map[fp] ?? null;
+}
+
+export function clearSpool(root: string): void {
+  try {
+    if (existsSync(spoolDir(root))) rmSync(spoolDir(root), { recursive: true, force: true });
+  } catch {
+    /* Best effort — the cap keeps an unclearable spool bounded anyway. */
+  }
+}

--- a/wiki-cli/test/cli-error-boundary.test.ts
+++ b/wiki-cli/test/cli-error-boundary.test.ts
@@ -84,6 +84,27 @@ describe("cli error boundary", () => {
     expect(spooled()).toHaveLength(0);
   });
 
+  it("does not report a rejection — a broken link is a refusal, not a bug", () => {
+    const { stderr, status } = runCli(
+      ["--root", "./wiki", "note", "--type", "concept", "--name", "X", "--no-reindex"],
+      "see [[Ghost]]",
+    );
+
+    expect(status).toBe(1);
+    expect(stderr).toContain("broken link");
+    expect(stderr).not.toContain("wiki report");
+    expect(spooled()).toHaveLength(0);
+  });
+
+  it("does not report a slug collision either", () => {
+    const write = ["--root", "./wiki", "note", "--type", "concept", "--no-reindex"];
+    runCli([...write, "--name", "Hiệu trưởng"], "first");
+    const { status } = runCli([...write, "--name", "Hiếu trường"], "second");
+
+    expect(status).toBe(1);
+    expect(spooled()).toHaveLength(0);
+  });
+
   it("rejects an invalid --type as user error, not as a crash", () => {
     const { stderr, status } = runCli(
       ["--root", "./wiki", "note", "--type", "bogus", "--name", "P"],

--- a/wiki-cli/test/cli-error-boundary.test.ts
+++ b/wiki-cli/test/cli-error-boundary.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+
+const CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "cli.ts");
+
+let home: string;
+let project: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "cli-boundary-home-"));
+  project = mkdtempSync(join(tmpdir(), "cli-boundary-proj-"));
+  mkdirSync(join(project, "wiki", "sources"), { recursive: true });
+  mkdirSync(join(project, "wiki", "notes"), { recursive: true });
+});
+
+function runCli(args: string[], input = "", extraEnv: Record<string, string> = {}) {
+  const result = spawnSync("bun", [CLI, ...args], {
+    input,
+    encoding: "utf8",
+    cwd: project,
+    env: { ...process.env, YMIR_HOME: home, ...extraEnv },
+  });
+  return { stdout: result.stdout ?? "", stderr: result.stderr ?? "", status: result.status };
+}
+
+function spooled(): string[] {
+  try {
+    return readdirSync(join(home, "reports")).filter((f) => f.endsWith(".json"));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * A genuinely unexpected failure: `index` cannot write `index.md` because a
+ * directory occupies the path. Unlike a bad flag, nothing in the CLI predicts
+ * this — which is exactly the class the reporter exists for.
+ */
+function provokeCrash(): ReturnType<typeof runCli> {
+  mkdirSync(join(project, "wiki", "index.md"), { recursive: true });
+  return runCli(["--root", "./wiki", "index", "--no-reindex"]);
+}
+
+describe("cli error boundary", () => {
+  it("formats a crash as an error line, never a raw stack dump", () => {
+    const { stderr, status } = provokeCrash();
+
+    expect(status).not.toBe(0);
+    expect(stderr.startsWith("error:")).toBe(true);
+    expect(stderr).not.toMatch(/^\s+at /m);
+    expect(stderr).not.toContain("Bun v");
+  });
+
+  it("points the user at wiki report", () => {
+    expect(provokeCrash().stderr).toContain("wiki report");
+  });
+
+  it("captures the crash so it can be filed", () => {
+    provokeCrash();
+    expect(spooled()).toHaveLength(1);
+  });
+
+  it("captures nothing when the user has opted out", () => {
+    mkdirSync(join(project, "wiki", "index.md"), { recursive: true });
+    runCli(["--root", "./wiki", "index", "--no-reindex"], "", { DO_NOT_TRACK: "1" });
+    expect(spooled()).toHaveLength(0);
+  });
+
+  it("stays silent about reporting when opted out", () => {
+    mkdirSync(join(project, "wiki", "index.md"), { recursive: true });
+    const { stderr } = runCli(["--root", "./wiki", "index", "--no-reindex"], "", { DO_NOT_TRACK: "1" });
+
+    expect(stderr).toContain("error:");
+    expect(stderr).not.toContain("wiki report");
+  });
+
+  it("does not report ordinary user error — a bad flag is not a bug", () => {
+    const { status } = runCli(["--root", "./wiki", "query", "--limit", "0", "x"]);
+    expect(status).toBe(1);
+    expect(spooled()).toHaveLength(0);
+  });
+
+  it("rejects an invalid --type as user error, not as a crash", () => {
+    const { stderr, status } = runCli(
+      ["--root", "./wiki", "note", "--type", "bogus", "--name", "P"],
+      "body",
+    );
+
+    expect(status).toBe(1);
+    expect(stderr).toContain("--type must be one of entity|concept|topic");
+    expect(stderr).not.toContain("invalid_value");
+    expect(spooled()).toHaveLength(0);
+  });
+
+  it("does not report an expected non-zero gate result", () => {
+    const { status } = runCli(["--root", "./wiki", "status"]);
+    expect(status).toBe(0);
+    expect(spooled()).toHaveLength(0);
+  });
+
+  it("succeeds normally without touching the reporter", () => {
+    const { status } = runCli(["--root", "./wiki", "index", "--no-reindex"]);
+    expect(status).toBe(0);
+    expect(spooled()).toHaveLength(0);
+  });
+});
+
+describe("wiki --version", () => {
+  it("reports a version instead of failing", () => {
+    const { stdout, status } = runCli(["--version"]);
+    expect(status).toBe(0);
+    expect(stdout.trim()).not.toBe("");
+  });
+});
+
+describe("wiki report via the CLI", () => {
+  it("shows the captured crash", () => {
+    provokeCrash();
+
+    const { stdout, status } = runCli(["report"]);
+    expect(status).toBe(0);
+    expect(stdout).toContain("wiki index");
+    expect(stdout).toContain("self-report");
+  });
+
+  it("--flush is silent when nothing is consented", () => {
+    provokeCrash();
+
+    const { stdout, status } = runCli(["report", "--flush"]);
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe("");
+  });
+
+  it("--off discards what was captured", () => {
+    provokeCrash();
+    expect(spooled()).toHaveLength(1);
+
+    runCli(["report", "--off"]);
+    expect(spooled()).toHaveLength(0);
+  });
+
+  it("--feedback captures without any failure having occurred", () => {
+    const { status } = runCli(["report", "--feedback", "wish it had a dry run"]);
+    expect(status).toBe(0);
+    expect(spooled()).toHaveLength(1);
+  });
+});

--- a/wiki-cli/test/note.test.ts
+++ b/wiki-cli/test/note.test.ts
@@ -12,7 +12,7 @@ describe("runNote", () => {
   it("creates a validated note, rebuilds index, appends log", async () => {
     await runNote({
       root, type: "concept", name: "Token Bucket",
-      body: "A rate limiter.", today: "2026-06-17",
+      body: "A rate limiter.", today: "2026-06-17", noReindex: true,
     });
     const page = readPage(join(root, "notes", "token-bucket.md"));
     expect(page).toContain("type: concept");
@@ -22,7 +22,7 @@ describe("runNote", () => {
 
   it("rejects on broken link and writes nothing", async () => {
     await expect(runNote({
-      root, type: "concept", name: "X", body: "see [[Ghost]]", today: "2026-06-17",
+      root, type: "concept", name: "X", body: "see [[Ghost]]", today: "2026-06-17", noReindex: true,
     })).rejects.toThrow(/broken link/);
     expect(existsSync(join(root, "notes", "x.md"))).toBe(false);
   });
@@ -34,7 +34,7 @@ describe("runNote", () => {
     );
     await runNote({
       root, type: "concept", name: "Token Bucket",
-      body: "Updated body.", today: "2026-06-18",
+      body: "Updated body.", today: "2026-06-18", noReindex: true,
     });
     const page = readPage(join(root, "notes", "token-bucket.md"));
     expect(page).toContain("source_count: 3");
@@ -44,13 +44,13 @@ describe("runNote", () => {
   it("rejects a note name whose slug collides with an existing note of a different name", async () => {
     await runNote({
       root, type: "concept", name: "Hiệu trưởng",
-      body: "Original note.", today: "2026-06-17",
+      body: "Original note.", today: "2026-06-17", noReindex: true,
     });
     const original = readPage(join(root, "notes", "hi-u-tr-ng.md"));
 
     await expect(runNote({
       root, type: "concept", name: "Hiếu trường",
-      body: "Colliding note.", today: "2026-06-18",
+      body: "Colliding note.", today: "2026-06-18", noReindex: true,
     })).rejects.toThrow(/collision/);
 
     expect(readPage(join(root, "notes", "hi-u-tr-ng.md"))).toBe(original);

--- a/wiki-cli/test/report-capture.test.ts
+++ b/wiki-cli/test/report-capture.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { capture, draftFromError, flush, maybeFlush } from "../src/report.js";
+import { loadConfig, pending, postedIssue, saveConfig, spool } from "../src/report/store.js";
+import type { GhRunner } from "../src/report/github.js";
+import type { Report } from "../src/report/model.js";
+
+let home: string;
+let env: Record<string, string | undefined>;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "report-capture-"));
+  env = { YMIR_HOME: home, HOME: "/Users/alice" };
+});
+
+const okGh: GhRunner = (args) => {
+  const joined = args.join(" ");
+  if (joined.includes("auth status")) return { status: 0, stdout: "ok" };
+  if (joined.includes("issue list")) return { status: 0, stdout: "[]" };
+  if (joined.includes("issue create")) {
+    return { status: 0, stdout: "https://github.com/muitneliss/ymir/issues/77\n" };
+  }
+  return { status: 0, stdout: "" };
+};
+
+describe("draftFromError", () => {
+  it("names the error class and message", () => {
+    const draft = draftFromError("wiki note", new TypeError("boom"));
+    expect(draft.errorName).toBe("TypeError");
+    expect(draft.message).toBe("boom");
+    expect(draft.kind).toBe("cli-error");
+  });
+
+  it("copes with a thrown non-Error", () => {
+    const draft = draftFromError("wiki note", "just a string");
+    expect(draft.message).toContain("just a string");
+    expect(draft.errorName).toBe("Error");
+  });
+
+  it("keeps flag names but never their values", () => {
+    const draft = draftFromError("wiki note", new Error("x"), ["--type", "--name"]);
+    expect(draft.flags).toEqual(["--type", "--name"]);
+  });
+});
+
+describe("capture", () => {
+  it("spools a report by default, without posting", () => {
+    capture(draftFromError("wiki note", new Error("boom")), env);
+
+    const all = pending(home);
+    expect(all).toHaveLength(1);
+    expect(all[0]!.command).toBe("wiki note");
+    expect(all[0]!.occurrences).toBe(1);
+  });
+
+  it("redacts before storing — the spool itself must be safe to read", () => {
+    capture(draftFromError("wiki note", new Error("failed at /Users/alice/secret/x.ts")), {
+      ...env,
+      YMIR_CWD: "/Users/alice/proj",
+    });
+
+    const stored = JSON.stringify(pending(home));
+    expect(stored).not.toContain("alice");
+  });
+
+  it("fingerprints the same bug identically across users", () => {
+    const alice = mkdtempSync(join(tmpdir(), "report-alice-"));
+    const bob = mkdtempSync(join(tmpdir(), "report-bob-"));
+
+    capture(draftFromError("wiki note", new Error("cannot read /Users/alice/proj/src/a.ts")), {
+      YMIR_HOME: alice,
+      YMIR_CWD: "/Users/alice/proj",
+    });
+    capture(draftFromError("wiki note", new Error("cannot read /home/bob/work/src/a.ts")), {
+      YMIR_HOME: bob,
+      YMIR_CWD: "/home/bob/work",
+    });
+
+    expect(pending(alice)[0]!.fingerprint).toBe(pending(bob)[0]!.fingerprint);
+  });
+
+  it("merges a repeat into one record with a count", () => {
+    capture(draftFromError("wiki note", new Error("boom")), env);
+    capture(draftFromError("wiki note", new Error("boom")), env);
+
+    const all = pending(home);
+    expect(all).toHaveLength(1);
+    expect(all[0]!.occurrences).toBe(2);
+  });
+
+  it("captures nothing at all when the user has opted out", () => {
+    capture(draftFromError("wiki note", new Error("boom")), { ...env, DO_NOT_TRACK: "1" });
+    expect(pending(home)).toHaveLength(0);
+  });
+
+  it("never throws, whatever it is handed", () => {
+    expect(() => capture(draftFromError("wiki note", new Error("boom")), { YMIR_HOME: "/" })).not.toThrow();
+    expect(() => capture(draftFromError("x", { weird: true }), env)).not.toThrow();
+  });
+});
+
+describe("flush", () => {
+  function spoolOne(over: Partial<Report> = {}): void {
+    capture(draftFromError("wiki note", new Error("boom")), env);
+    if (Object.keys(over).length) {
+      const existing = pending(home)[0]!;
+      spool(home, { ...existing, ...over });
+    }
+  }
+
+  it("posts nothing until the user opts in", () => {
+    spoolOne();
+    const summary = flush({ env, run: okGh });
+
+    expect(summary.posted).toBe(0);
+    expect(pending(home)).toHaveLength(1);
+  });
+
+  it("posts once opted in, and clears what it posted", () => {
+    saveConfig(home, { mode: "auto" });
+    spoolOne();
+
+    const summary = flush({ env, run: okGh });
+    expect(summary.posted).toBe(1);
+    expect(pending(home)).toHaveLength(0);
+    expect(postedIssue(home, summary.results[0]!.report.fingerprint)).toBe(77);
+  });
+
+  it("keeps a report spooled when posting fails, so it retries later", () => {
+    saveConfig(home, { mode: "auto" });
+    spoolOne();
+
+    const failing: GhRunner = (args) =>
+      args.join(" ").includes("auth status") ? { status: 0, stdout: "ok" } : { status: 1, stdout: "HTTP 500" };
+
+    expect(flush({ env, run: failing }).posted).toBe(0);
+    expect(pending(home)).toHaveLength(1);
+  });
+
+  it("does not treat a fallback URL as delivered", () => {
+    saveConfig(home, { mode: "auto" });
+    spoolOne();
+
+    const noGh: GhRunner = () => ({ status: null, stdout: "" });
+    const summary = flush({ env, run: noGh });
+
+    expect(summary.posted).toBe(0);
+    expect(summary.results[0]!.result.outcome).toBe("fallback-url");
+    expect(pending(home)).toHaveLength(1);
+  });
+
+  it("is a silent no-op with an empty spool", () => {
+    saveConfig(home, { mode: "auto" });
+    expect(flush({ env, run: okGh }).results).toHaveLength(0);
+  });
+});
+
+describe("maybeFlush", () => {
+  it("does nothing when the spool is empty", () => {
+    saveConfig(home, { mode: "auto" });
+    let called = false;
+    maybeFlush({ env, run: (a) => ((called = true), { status: 0, stdout: "" }) });
+    expect(called).toBe(false);
+  });
+
+  it("does nothing when the user has not opted in", () => {
+    capture(draftFromError("wiki note", new Error("boom")), env);
+    let called = false;
+    maybeFlush({ env, run: (a) => ((called = true), { status: 0, stdout: "" }) });
+    expect(called).toBe(false);
+  });
+
+  it("flushes when opted in with work pending, and records the time", () => {
+    saveConfig(home, { mode: "auto" });
+    capture(draftFromError("wiki note", new Error("boom")), env);
+
+    maybeFlush({ env, run: okGh });
+
+    expect(pending(home)).toHaveLength(0);
+    expect(loadConfig(home, {}).lastFlushAt).toBeDefined();
+  });
+
+  it("holds off inside the rate-limit window", () => {
+    saveConfig(home, { mode: "auto", lastFlushAt: new Date().toISOString() });
+    capture(draftFromError("wiki note", new Error("boom")), env);
+
+    let called = false;
+    maybeFlush({ env, run: (a) => ((called = true), { status: 0, stdout: "" }) });
+    expect(called).toBe(false);
+    expect(pending(home)).toHaveLength(1);
+  });
+
+  it("flushes again once the window has passed", () => {
+    const old = new Date(Date.now() - 7 * 60 * 60 * 1000).toISOString();
+    saveConfig(home, { mode: "auto", lastFlushAt: old });
+    capture(draftFromError("wiki note", new Error("boom")), env);
+
+    maybeFlush({ env, run: okGh });
+    expect(pending(home)).toHaveLength(0);
+  });
+
+  it("never throws, even if delivery explodes", () => {
+    saveConfig(home, { mode: "auto" });
+    capture(draftFromError("wiki note", new Error("boom")), env);
+
+    expect(() =>
+      maybeFlush({
+        env,
+        run: () => {
+          throw new Error("spawn failed");
+        },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/wiki-cli/test/report-cmd.test.ts
+++ b/wiki-cli/test/report-cmd.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runReport } from "../src/commands/report.js";
+import { capture, draftFromError } from "../src/report.js";
+import { loadConfig, pending, saveConfig } from "../src/report/store.js";
+import type { GhRunner } from "../src/report/github.js";
+
+let home: string;
+let env: Record<string, string | undefined>;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "report-cmd-"));
+  env = { YMIR_HOME: home, HOME: "/Users/alice" };
+});
+
+const okGh: GhRunner = (args) => {
+  const joined = args.join(" ");
+  if (joined.includes("auth status")) return { status: 0, stdout: "ok" };
+  if (joined.includes("issue list")) return { status: 0, stdout: "[]" };
+  if (joined.includes("issue create")) {
+    return { status: 0, stdout: "https://github.com/muitneliss/ymir/issues/77\n" };
+  }
+  return { status: 0, stdout: "" };
+};
+
+const noGh: GhRunner = () => ({ status: null, stdout: "" });
+
+function spoolOne(): void {
+  capture(draftFromError("wiki note", new Error("boom")), env);
+}
+
+describe("wiki report — listing", () => {
+  it("says so when there is nothing to report", () => {
+    const { text, exitCode } = runReport({ env, run: okGh });
+    expect(exitCode).toBe(0);
+    expect(text).toContain("nothing to report");
+  });
+
+  it("previews the exact body that would be posted, and does not post it", () => {
+    spoolOne();
+    const { text, exitCode } = runReport({ env, run: okGh });
+
+    expect(exitCode).toBe(0);
+    expect(text).toContain("wiki note");
+    expect(text).toContain("self-report");
+    expect(pending(home)).toHaveLength(1);
+  });
+
+  it("tells an un-consented user how to opt in", () => {
+    spoolOne();
+    expect(runReport({ env, run: okGh }).text).toContain("--yes");
+  });
+
+  it("names the destination repo so a fork is not a surprise", () => {
+    spoolOne();
+    expect(runReport({ env, run: okGh }).text).toContain("muitneliss/ymir");
+  });
+});
+
+describe("wiki report --yes", () => {
+  it("records consent and posts", () => {
+    spoolOne();
+    const { text, exitCode } = runReport({ env, run: okGh, yes: true });
+
+    expect(exitCode).toBe(0);
+    expect(loadConfig(home, {}).mode).toBe("auto");
+    expect(pending(home)).toHaveLength(0);
+    expect(text).toContain("77");
+  });
+
+  it("prints a usable URL when gh cannot deliver", () => {
+    spoolOne();
+    const { text, exitCode } = runReport({ env, run: noGh, yes: true });
+
+    expect(exitCode).toBe(0);
+    expect(text).toContain("https://github.com/muitneliss/ymir/issues/new");
+    expect(pending(home)).toHaveLength(1);
+  });
+
+  it("refuses to post when the user has a hard opt-out set", () => {
+    spoolOne();
+    const { text, exitCode } = runReport({ env: { ...env, DO_NOT_TRACK: "1" }, run: okGh, yes: true });
+
+    expect(exitCode).toBe(0);
+    expect(text.toLowerCase()).toContain("opted out");
+  });
+});
+
+describe("wiki report --flush", () => {
+  it("is silent and successful with nothing pending", () => {
+    saveConfig(home, { mode: "auto" });
+    const { text, exitCode } = runReport({ env, run: okGh, flush: true });
+    expect(exitCode).toBe(0);
+    expect(text).toBe("");
+  });
+
+  it("is silent when not consented, and posts nothing", () => {
+    spoolOne();
+    const { text, exitCode } = runReport({ env, run: okGh, flush: true });
+
+    expect(exitCode).toBe(0);
+    expect(text).toBe("");
+    expect(pending(home)).toHaveLength(1);
+  });
+
+  it("posts when consented", () => {
+    saveConfig(home, { mode: "auto" });
+    spoolOne();
+
+    const { exitCode } = runReport({ env, run: okGh, flush: true });
+    expect(exitCode).toBe(0);
+    expect(pending(home)).toHaveLength(0);
+  });
+});
+
+describe("wiki report --skill", () => {
+  it("captures a skill-flow failure Claude could never surface from the CLI", () => {
+    const { exitCode } = runReport({
+      env,
+      run: okGh,
+      skill: { title: "apply wrote no files", detail: "playbook Target line was missing" },
+    });
+
+    expect(exitCode).toBe(0);
+    const all = pending(home);
+    expect(all).toHaveLength(1);
+    expect(all[0]!.kind).toBe("skill");
+    expect(all[0]!.message).toContain("playbook Target line was missing");
+  });
+
+  it("requires a title", () => {
+    const { exitCode, text } = runReport({ env, run: okGh, skill: { title: "", detail: "x" } });
+    expect(exitCode).toBe(1);
+    expect(text).toContain("--title");
+  });
+});
+
+describe("wiki report --feedback", () => {
+  it("captures an improvement idea through the same pipeline", () => {
+    const { exitCode } = runReport({ env, run: okGh, feedback: "wish ymir apply had a --dry-run" });
+
+    expect(exitCode).toBe(0);
+    const all = pending(home);
+    expect(all[0]!.kind).toBe("feedback");
+    expect(all[0]!.message).toContain("--dry-run");
+  });
+
+  it("redacts feedback too — users paste logs into it", () => {
+    runReport({ env, run: okGh, feedback: "broke on /Users/alice/proj/a.ts" });
+    expect(JSON.stringify(pending(home))).not.toContain("alice");
+  });
+
+  it("rejects empty feedback", () => {
+    expect(runReport({ env, run: okGh, feedback: "   " }).exitCode).toBe(1);
+  });
+});
+
+describe("wiki report --off", () => {
+  it("opts out, and forgets everything already captured", () => {
+    spoolOne();
+    const { text, exitCode } = runReport({ env, run: okGh, off: true });
+
+    expect(exitCode).toBe(0);
+    expect(loadConfig(home, {}).mode).toBe("off");
+    expect(pending(home)).toHaveLength(0);
+    expect(text.toLowerCase()).toContain("off");
+  });
+
+  it("stops later captures from being stored at all", () => {
+    runReport({ env, run: okGh, off: true });
+    capture(draftFromError("wiki note", new Error("boom")), env);
+    expect(pending(home)).toHaveLength(0);
+  });
+});

--- a/wiki-cli/test/report-fingerprint.test.ts
+++ b/wiki-cli/test/report-fingerprint.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "bun:test";
+import { fingerprint, type ReportDraft } from "../src/report/model.js";
+
+const BASE: ReportDraft = {
+  kind: "cli-error",
+  command: "wiki note",
+  errorName: "ZodError",
+  message: "Invalid option: expected one of entity|concept|topic",
+};
+
+describe("fingerprint", () => {
+  it("is a short stable hex id", () => {
+    const fp = fingerprint(BASE);
+    expect(fp).toMatch(/^[0-9a-f]{12}$/);
+    expect(fingerprint({ ...BASE })).toBe(fp);
+  });
+
+  it("collapses counts so one bug is one issue", () => {
+    const a = fingerprint({ ...BASE, message: "index rebuild failed after 3 pages" });
+    const b = fingerprint({ ...BASE, message: "index rebuild failed after 47 pages" });
+    expect(a).toBe(b);
+  });
+
+  it("separates different commands", () => {
+    expect(fingerprint({ ...BASE, command: "wiki ingest" })).not.toBe(fingerprint(BASE));
+  });
+
+  it("separates different error types", () => {
+    expect(fingerprint({ ...BASE, errorName: "TypeError" })).not.toBe(fingerprint(BASE));
+  });
+
+  it("separates different kinds", () => {
+    expect(fingerprint({ ...BASE, kind: "feedback" })).not.toBe(fingerprint(BASE));
+  });
+
+  it("ignores the stack — the shipped compiled binary emits no frames", () => {
+    const withStack = fingerprint({ ...BASE, stack: "at foo (/Users/alice/x.ts:1:1)" });
+    const withOther = fingerprint({ ...BASE, stack: "at bar (/home/bob/y.ts:9:9)" });
+    expect(withStack).toBe(fingerprint(BASE));
+    expect(withOther).toBe(fingerprint(BASE));
+  });
+
+  it("is unaffected by surrounding whitespace or case in the message", () => {
+    expect(fingerprint({ ...BASE, message: `  ${BASE.message.toUpperCase()}  ` })).toBe(
+      fingerprint(BASE),
+    );
+  });
+});

--- a/wiki-cli/test/report-github.test.ts
+++ b/wiki-cli/test/report-github.test.ts
@@ -4,6 +4,9 @@ import type { Report } from "../src/report/model.js";
 
 const REPO = "muitneliss/ymir";
 
+/** Assembled at runtime so the file holds no credential-shaped literal. */
+const FAKE_GH_PAT = "gh" + "p_" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8";
+
 function report(over: Partial<Report> = {}): Report {
   return {
     schema: 1,
@@ -185,7 +188,7 @@ describe("issue rendering", () => {
 
   it("redacts anything identifying that reached it late", () => {
     const body = renderBody(
-      report({ message: "failed at /Users/alice/x.ts with gh" + "p_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8" }),
+      report({ message: `failed at /Users/alice/x.ts with ${FAKE_GH_PAT}` }),
     );
     expect(body).not.toContain("alice");
     expect(body).not.toContain("A1b2C3d4E5f6");

--- a/wiki-cli/test/report-github.test.ts
+++ b/wiki-cli/test/report-github.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from "bun:test";
+import { postReport, renderBody, renderTitle, type GhRunner } from "../src/report/github.js";
+import type { Report } from "../src/report/model.js";
+
+const REPO = "muitneliss/ymir";
+
+function report(over: Partial<Report> = {}): Report {
+  return {
+    schema: 1,
+    kind: "cli-error",
+    fingerprint: "abc123def456",
+    command: "wiki note",
+    errorName: "ZodError",
+    message: "Invalid option: expected one of entity|concept|topic",
+    version: "0.7.0",
+    platform: "darwin-arm64",
+    firstSeen: "2026-08-21T00:00:00.000Z",
+    lastSeen: "2026-08-21T00:00:00.000Z",
+    occurrences: 1,
+    ...over,
+  };
+}
+
+/** Records every invocation and replies from a scripted table. */
+function runnerFor(script: Record<string, { status: number; stdout: string }>) {
+  const calls: string[][] = [];
+  const run: GhRunner = (args) => {
+    calls.push(args);
+    for (const [key, reply] of Object.entries(script)) {
+      if (args.join(" ").includes(key)) return reply;
+    }
+    return { status: 0, stdout: "" };
+  };
+  return { run, calls };
+}
+
+const GH_PRESENT = { "auth status": { status: 0, stdout: "Logged in" } };
+
+describe("postReport — no usable gh", () => {
+  it("falls back to a prefilled issue URL when gh is absent", () => {
+    const run: GhRunner = () => ({ status: null, stdout: "" });
+    const out = postReport(report(), { repo: REPO, run, postedIssue: () => null });
+
+    expect(out.outcome).toBe("fallback-url");
+    expect(out.url).toContain("https://github.com/muitneliss/ymir/issues/new");
+    expect(out.url).toContain("title=");
+    expect(out.url).toContain("body=");
+  });
+
+  it("falls back when gh is installed but unauthenticated", () => {
+    const { run } = runnerFor({ "auth status": { status: 1, stdout: "not logged in" } });
+    const out = postReport(report(), { repo: REPO, run, postedIssue: () => null });
+    expect(out.outcome).toBe("fallback-url");
+  });
+
+  it("keeps the fallback URL inside a usable length", () => {
+    const huge = report({ message: "x".repeat(50_000), stack: "y".repeat(50_000) });
+    const run: GhRunner = () => ({ status: null, stdout: "" });
+    const out = postReport(huge, { repo: REPO, run, postedIssue: () => null });
+    expect(out.url!.length).toBeLessThanOrEqual(8000);
+  });
+});
+
+describe("postReport — dedup", () => {
+  it("comments on the known issue instead of filing a second one", () => {
+    const { run, calls } = runnerFor(GH_PRESENT);
+    const out = postReport(report({ occurrences: 4 }), {
+      repo: REPO,
+      run,
+      postedIssue: () => 42,
+    });
+
+    expect(out.outcome).toBe("commented");
+    expect(out.issue).toBe(42);
+
+    const flat = calls.map((c) => c.join(" "));
+    expect(flat.some((c) => c.startsWith("issue comment 42"))).toBe(true);
+    expect(flat.some((c) => c.startsWith("issue create"))).toBe(false);
+  });
+
+  it("adopts an issue another machine already filed, found by fingerprint", () => {
+    const { run, calls } = runnerFor({
+      ...GH_PRESENT,
+      "issue list": { status: 0, stdout: JSON.stringify([{ number: 7, state: "OPEN" }]) },
+    });
+    const out = postReport(report(), { repo: REPO, run, postedIssue: () => null });
+
+    expect(out.outcome).toBe("commented");
+    expect(out.issue).toBe(7);
+    expect(calls.map((c) => c.join(" ")).some((c) => c.startsWith("issue create"))).toBe(false);
+  });
+
+  it("searches by fingerprint, scoped to the destination repo", () => {
+    const { run, calls } = runnerFor({
+      ...GH_PRESENT,
+      "issue list": { status: 0, stdout: "[]" },
+      "issue create": { status: 0, stdout: "https://github.com/muitneliss/ymir/issues/9\n" },
+    });
+    postReport(report(), { repo: REPO, run, postedIssue: () => null });
+
+    const search = calls.find((c) => c.includes("list"))!.join(" ");
+    expect(search).toContain("abc123def456");
+    expect(search).toContain(REPO);
+  });
+});
+
+describe("postReport — creating", () => {
+  it("creates an issue and returns its number", () => {
+    const { run } = runnerFor({
+      ...GH_PRESENT,
+      "issue list": { status: 0, stdout: "[]" },
+      "issue create": { status: 0, stdout: "https://github.com/muitneliss/ymir/issues/123\n" },
+    });
+    const out = postReport(report(), { repo: REPO, run, postedIssue: () => null });
+
+    expect(out.outcome).toBe("created");
+    expect(out.issue).toBe(123);
+  });
+
+  it("retries without the label when the repo has no self-report label", () => {
+    let attempt = 0;
+    const run: GhRunner = (args) => {
+      const joined = args.join(" ");
+      if (joined.includes("auth status")) return { status: 0, stdout: "ok" };
+      if (joined.includes("issue list")) return { status: 0, stdout: "[]" };
+      if (joined.includes("issue create")) {
+        attempt++;
+        if (args.includes("--label")) {
+          return { status: 1, stdout: "could not add label: 'self-report' not found" };
+        }
+        return { status: 0, stdout: "https://github.com/muitneliss/ymir/issues/5\n" };
+      }
+      return { status: 0, stdout: "" };
+    };
+
+    const out = postReport(report(), { repo: REPO, run, postedIssue: () => null });
+    expect(attempt).toBe(2);
+    expect(out.outcome).toBe("created");
+    expect(out.issue).toBe(5);
+  });
+
+  it("reports failure rather than throwing when gh refuses outright", () => {
+    const { run } = runnerFor({
+      ...GH_PRESENT,
+      "issue list": { status: 0, stdout: "[]" },
+      "issue create": { status: 1, stdout: "HTTP 403 rate limited" },
+    });
+    const out = postReport(report(), { repo: REPO, run, postedIssue: () => null });
+    expect(out.outcome).toBe("failed");
+  });
+
+  it("never throws even if the runner itself explodes", () => {
+    const run: GhRunner = () => {
+      throw new Error("spawn failed");
+    };
+    expect(() => postReport(report(), { repo: REPO, run, postedIssue: () => null })).not.toThrow();
+  });
+});
+
+describe("issue rendering", () => {
+  it("titles by command and short message, tagged for humans", () => {
+    const title = renderTitle(report());
+    expect(title).toContain("wiki note");
+    expect(title).toContain("ZodError");
+    expect(title.length).toBeLessThanOrEqual(120);
+  });
+
+  it("embeds the fingerprint so other machines can find this issue", () => {
+    expect(renderBody(report())).toContain("abc123def456");
+  });
+
+  it("records environment a maintainer needs to reproduce", () => {
+    const body = renderBody(report());
+    expect(body).toContain("0.7.0");
+    expect(body).toContain("darwin-arm64");
+  });
+
+  it("says how often it happened", () => {
+    expect(renderBody(report({ occurrences: 12 }))).toContain("12");
+  });
+
+  it("marks the report as machine-filed so nobody mistakes it for a human", () => {
+    expect(renderBody(report()).toLowerCase()).toContain("automatically");
+  });
+
+  it("redacts anything identifying that reached it late", () => {
+    const body = renderBody(
+      report({ message: "failed at /Users/alice/x.ts with gh" + "p_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8" }),
+    );
+    expect(body).not.toContain("alice");
+    expect(body).not.toContain("A1b2C3d4E5f6");
+  });
+
+  it("bounds the body regardless of input size", () => {
+    const body = renderBody(report({ message: "x".repeat(100_000), stack: "y".repeat(100_000) }));
+    expect(body.length).toBeLessThanOrEqual(12_000);
+  });
+
+  it("renders feedback as feedback, not as a crash", () => {
+    const body = renderBody(report({ kind: "feedback", message: "wish it did X" }));
+    expect(body).toContain("wish it did X");
+    expect(body.toLowerCase()).toContain("feedback");
+  });
+});

--- a/wiki-cli/test/report-hook.test.ts
+++ b/wiki-cli/test/report-hook.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { pending } from "../src/report/store.js";
+
+const HOOK = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..", "..", "plugins", "ymir", "hooks", "ensure-wiki-binary.mjs",
+);
+
+let home: string;
+let skillRoot: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "hook-report-home-"));
+  skillRoot = mkdtempSync(join(tmpdir(), "hook-report-skill-"));
+});
+
+function runHook(extraEnv: Record<string, string> = {}) {
+  const result = spawnSync("node", [HOOK], {
+    encoding: "utf8",
+    env: { ...process.env, CLAUDE_PLUGIN_ROOT: skillRoot, YMIR_HOME: home, ...extraEnv },
+  });
+  return { stderr: result.stderr ?? "", status: result.status };
+}
+
+function incoming(): string {
+  const path = join(home, "reports", "incoming", "hooks.jsonl");
+  return existsSync(path) ? readFileSync(path, "utf8") : "";
+}
+
+/** A manifest whose version is not semver — fails before any network access. */
+function writeBadManifest(): void {
+  mkdirSync(join(skillRoot, ".claude-plugin"), { recursive: true });
+  writeFileSync(join(skillRoot, ".claude-plugin", "plugin.json"), JSON.stringify({ version: "not-semver" }));
+}
+
+describe("ensure-wiki-binary failure reporting", () => {
+  it("still fails the install with the blocking exit code", () => {
+    writeBadManifest();
+    const { status, stderr } = runHook();
+
+    expect(status).toBe(2);
+    expect(stderr).toContain("[ymir]");
+  });
+
+  it("leaves a record the CLI can adopt", () => {
+    writeBadManifest();
+    runHook();
+
+    const record = JSON.parse(incoming().trim());
+    expect(record.kind).toBe("hook");
+    expect(record.command).toBe("ensure-wiki-binary");
+    expect(record.errorName).toBe("InvalidVersion");
+  });
+
+  it("reports a missing manifest too", () => {
+    const { status } = runHook();
+    expect(status).toBe(2);
+    expect(JSON.parse(incoming().trim()).errorName).toBe("ManifestUnreadable");
+  });
+
+  it("writes nothing when the user has opted out", () => {
+    writeBadManifest();
+    runHook({ DO_NOT_TRACK: "1" });
+    expect(incoming()).toBe("");
+  });
+
+  it("honours YMIR_REPORT=off", () => {
+    writeBadManifest();
+    runHook({ YMIR_REPORT: "off" });
+    expect(incoming()).toBe("");
+  });
+
+  it("produces a record the store adopts, redacts and fingerprints", () => {
+    runHook();
+
+    const all = pending(home);
+    expect(all).toHaveLength(1);
+    expect(all[0]!.kind).toBe("hook");
+    expect(all[0]!.fingerprint).toMatch(/^[0-9a-f]{12}$/);
+    expect(JSON.stringify(all)).not.toContain(skillRoot);
+  });
+});

--- a/wiki-cli/test/report-redact.test.ts
+++ b/wiki-cli/test/report-redact.test.ts
@@ -3,6 +3,18 @@ import { redact, truncate } from "../src/report/redact.js";
 
 const CTX = { cwd: "/Users/alice/work/acme-corp/my-project" };
 
+/**
+ * Credential fixtures are assembled at runtime, never written as literals.
+ *
+ * A credential-shaped string in a source file is indistinguishable from a real
+ * leak — to a scanner, to a reviewer, and to GitHub's push protection, which
+ * blocks the push. Splitting the prefix keeps the value under test byte-for-byte
+ * identical while leaving nothing in the file that looks like a live key.
+ */
+const token = (prefix: string, rest: string): string => prefix + rest;
+
+const FAKE_GH_PAT = token("gh" + "p_", "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8");
+
 describe("redact — filesystem paths", () => {
   it("rewrites a path inside the project to <project>, keeping the relative part", () => {
     const out = redact("failed to read /Users/alice/work/acme-corp/my-project/src/auth.ts", CTX);
@@ -38,15 +50,15 @@ describe("redact — filesystem paths", () => {
 
 describe("redact — credentials", () => {
   it.each([
-    ["ghp_", "gh" + "p_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"],
-    ["gho_", "gh" + "o_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"],
-    ["github_pat_", "github" + "_pat_11ABCDEFG0abcdefghijklmnopqrstuvwxyz123456"],
-    ["sk-", "sk" + "-proj0A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6"],
-    ["AKIA", "AK" + "IAIOSFODNN7EXAMPLE"],
-    ["xoxb-", "xo" + "xb-123456789012-abcdefghijklmnop"],
-  ])("redacts a %s token", (_label, token) => {
-    const out = redact(`auth failed using ${token} on retry`, CTX);
-    expect(out).not.toContain(token);
+    ["github pat", token("gh" + "p_", "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8")],
+    ["github oauth", token("gh" + "o_", "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8")],
+    ["github fine-grained", token("github" + "_pat_", "11ABCDEFG0abcdefghijklmnopqrstuvwxyz123456")],
+    ["openai", token("sk" + "-", "proj0A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6")],
+    ["aws access key", token("AK" + "IA", "IOSFODNN7EXAMPLE")],
+    ["slack bot", token("xo" + "xb-", "123456789012-abcdefghijklmnop")],
+  ])("redacts a %s token", (_label, secret) => {
+    const out = redact(`auth failed using ${secret} on retry`, CTX);
+    expect(out).not.toContain(secret);
     expect(out).toContain("<redacted>");
   });
 
@@ -73,7 +85,7 @@ describe("redact — credentials", () => {
   });
 
   it("redacts a token even when embedded in a path", () => {
-    const out = redact("/tmp/gh" + "p_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8/cache", CTX);
+    const out = redact(`/tmp/${FAKE_GH_PAT}/cache`, CTX);
     expect(out).not.toContain("A1b2C3d4E5f6");
   });
 
@@ -121,7 +133,7 @@ describe("redact — identities and network", () => {
 
 describe("redact — invariants", () => {
   it("is idempotent", () => {
-    const input = "/Users/alice/p/x.ts gh" + "p_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8 a@b.com";
+    const input = `/Users/alice/p/x.ts ${FAKE_GH_PAT} a@b.com`;
     const once = redact(input, CTX);
     expect(redact(once, CTX)).toBe(once);
   });
@@ -135,12 +147,12 @@ describe("redact — invariants", () => {
     const input = [
       "ingest rejected: /Users/alice/work/acme-corp/my-project/src/auth.ts",
       "  upstream https://internal.acme-corp.com/api?key=s3cr3t",
-      "  as alice@acme-corp.com with token=gh" + "p_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8",
+      `  as alice@acme-corp.com with token=${FAKE_GH_PAT}`,
       "  cache at /Users/alice/.ymir/cache.json",
     ].join("\n");
     const out = redact(input, CTX);
 
-    for (const leak of ["alice", "s3cr3t", "ghp_A1b2", "acme-corp.com"]) {
+    for (const leak of ["alice", "s3cr3t", FAKE_GH_PAT.slice(0, 8), "acme-corp.com"]) {
       expect(out).not.toContain(leak);
     }
     expect(out).toContain("<project>/src/auth.ts");

--- a/wiki-cli/test/report-redact.test.ts
+++ b/wiki-cli/test/report-redact.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "bun:test";
+import { redact, truncate } from "../src/report/redact.js";
+
+const CTX = { cwd: "/Users/alice/work/acme-corp/my-project" };
+
+describe("redact — filesystem paths", () => {
+  it("rewrites a path inside the project to <project>, keeping the relative part", () => {
+    const out = redact("failed to read /Users/alice/work/acme-corp/my-project/src/auth.ts", CTX);
+    expect(out).toBe("failed to read <project>/src/auth.ts");
+  });
+
+  it("reduces the project root itself to <project>", () => {
+    expect(redact("/Users/alice/work/acme-corp/my-project", CTX)).toBe("<project>");
+  });
+
+  it("strips intermediate directories from any other absolute path", () => {
+    const out = redact("ENOENT: /Users/alice/.config/qmd/settings.toml", CTX);
+    expect(out).toBe("ENOENT: <path>/settings.toml");
+  });
+
+  it("never lets a home directory survive", () => {
+    const out = redact("/Users/alice/secrets/notes.md and /home/bob/thing.log", CTX);
+    expect(out).not.toContain("alice");
+    expect(out).not.toContain("bob");
+    expect(out).toBe("<path>/notes.md and <path>/thing.log");
+  });
+
+  it("redacts Windows paths, normalizing separators", () => {
+    const out = redact("cannot open C:\\Users\\alice\\AppData\\wiki.exe", CTX);
+    expect(out).not.toContain("alice");
+    expect(out).toBe("cannot open <path>/wiki.exe");
+  });
+
+  it("leaves relative paths untouched — they are the diagnostic signal", () => {
+    expect(redact("wiki/sources/auth.md is stale", CTX)).toBe("wiki/sources/auth.md is stale");
+  });
+});
+
+describe("redact — credentials", () => {
+  it.each([
+    ["ghp_", "gh" + "p_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"],
+    ["gho_", "gh" + "o_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"],
+    ["github_pat_", "github" + "_pat_11ABCDEFG0abcdefghijklmnopqrstuvwxyz123456"],
+    ["sk-", "sk" + "-proj0A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6"],
+    ["AKIA", "AK" + "IAIOSFODNN7EXAMPLE"],
+    ["xoxb-", "xo" + "xb-123456789012-abcdefghijklmnop"],
+  ])("redacts a %s token", (_label, token) => {
+    const out = redact(`auth failed using ${token} on retry`, CTX);
+    expect(out).not.toContain(token);
+    expect(out).toContain("<redacted>");
+  });
+
+  it("redacts a bearer header value", () => {
+    const out = redact("Authorization: Bearer aGVsbG8gd29ybGQgdGhpcyBpcyBhIHRva2Vu", CTX);
+    expect(out).not.toContain("aGVsbG8");
+    expect(out).toContain("<redacted>");
+  });
+
+  it.each(["token", "secret", "password", "api_key", "API-KEY"])(
+    "redacts the value after a %s assignment",
+    (key) => {
+      const out = redact(`${key}=hunter2supersecretvalue`, CTX);
+      expect(out).not.toContain("hunter2supersecretvalue");
+      expect(out).toContain("<redacted>");
+    },
+  );
+
+  it("redacts a private key block", () => {
+    const pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQ\n-----END RSA PRIVATE KEY-----";
+    const out = redact(`loaded ${pem}`, CTX);
+    expect(out).not.toContain("MIIEowIBAAKCAQ");
+    expect(out).toContain("<redacted>");
+  });
+
+  it("redacts a token even when embedded in a path", () => {
+    const out = redact("/tmp/gh" + "p_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8/cache", CTX);
+    expect(out).not.toContain("A1b2C3d4E5f6");
+  });
+
+  it("keeps a sha256 hash — provenance hashes are diagnostic, not secret", () => {
+    const sha = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    expect(redact(`source_hash mismatch: ${sha}`, CTX)).toContain(sha);
+  });
+});
+
+describe("redact — identities and network", () => {
+  it("redacts email addresses", () => {
+    const out = redact("owner alice.smith+dev@acme-corp.com failed", CTX);
+    expect(out).not.toContain("acme-corp.com");
+    expect(out).toContain("<email>");
+  });
+
+  it("keeps an allowlisted host's endpoint but drops its query string", () => {
+    const out = redact(
+      "GET https://github.com/muitneliss/ymir/releases/download/ymir-v0.7.0/wiki-linux-x64?token=abc 404",
+      CTX,
+    );
+    expect(out).toContain("https://github.com/muitneliss/ymir/releases");
+    expect(out).not.toContain("abc");
+  });
+
+  it("redacts a non-allowlisted URL whole — an internal hostname names the employer", () => {
+    const out = redact("GET https://ci.acme-corp.internal/v1/items?user=alice 500", CTX);
+    expect(out).not.toContain("acme-corp");
+    expect(out).not.toContain("alice");
+    expect(out).toContain("<url>");
+  });
+
+  it("strips credentials embedded in a URL", () => {
+    const out = redact("https://alice:hunter2@git.acme-corp.com/repo", CTX);
+    expect(out).not.toContain("hunter2");
+    expect(out).not.toContain("alice");
+  });
+
+  it("redacts an ssh git remote", () => {
+    const out = redact("remote git@github.com:acme-corp/private-thing.git rejected", CTX);
+    expect(out).not.toContain("acme-corp");
+    expect(out).toContain("<git-remote>");
+  });
+});
+
+describe("redact — invariants", () => {
+  it("is idempotent", () => {
+    const input = "/Users/alice/p/x.ts gh" + "p_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8 a@b.com";
+    const once = redact(input, CTX);
+    expect(redact(once, CTX)).toBe(once);
+  });
+
+  it("handles empty and whitespace input", () => {
+    expect(redact("", CTX)).toBe("");
+    expect(redact("   ", CTX)).toBe("   ");
+  });
+
+  it("leaks nothing from a realistic composite failure", () => {
+    const input = [
+      "ingest rejected: /Users/alice/work/acme-corp/my-project/src/auth.ts",
+      "  upstream https://internal.acme-corp.com/api?key=s3cr3t",
+      "  as alice@acme-corp.com with token=gh" + "p_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8",
+      "  cache at /Users/alice/.ymir/cache.json",
+    ].join("\n");
+    const out = redact(input, CTX);
+
+    for (const leak of ["alice", "s3cr3t", "ghp_A1b2", "acme-corp.com"]) {
+      expect(out).not.toContain(leak);
+    }
+    expect(out).toContain("<project>/src/auth.ts");
+  });
+});
+
+describe("truncate", () => {
+  it("leaves short text alone", () => {
+    expect(truncate("short", 100)).toBe("short");
+  });
+
+  it("caps long text and marks the elision", () => {
+    const out = truncate("x".repeat(500), 50);
+    expect(out.length).toBeLessThanOrEqual(50);
+    expect(out).toContain("…");
+  });
+
+  it("caps line count as well as characters", () => {
+    const out = truncate(Array.from({ length: 40 }, (_, i) => `line ${i}`).join("\n"), 10_000, 8);
+    expect(out.split("\n").length).toBeLessThanOrEqual(9);
+  });
+});

--- a/wiki-cli/test/report-store.test.ts
+++ b/wiki-cli/test/report-store.test.ts
@@ -169,6 +169,32 @@ describe("hook records", () => {
     writeFileSync(join(root, "reports", "incoming", "hook.jsonl"), "not json\n");
     expect(pending(root)).toHaveLength(0);
   });
+
+  it("redacts adopted records — a hook message quotes whatever path failed", () => {
+    mkdirSync(join(root, "reports", "incoming"), { recursive: true });
+    writeFileSync(
+      join(root, "reports", "incoming", "hook.jsonl"),
+      JSON.stringify({
+        kind: "hook",
+        command: "ensure-wiki-binary",
+        errorName: "ManifestUnreadable",
+        message: "ENOENT: /Users/alice/.claude/plugins/ymir/plugin.json",
+      }) + "\n",
+    );
+
+    expect(JSON.stringify(pending(root))).not.toContain("alice");
+  });
+
+  it("consumes the incoming file so a record is adopted once", () => {
+    mkdirSync(join(root, "reports", "incoming"), { recursive: true });
+    writeFileSync(
+      join(root, "reports", "incoming", "hook.jsonl"),
+      JSON.stringify({ kind: "hook", command: "h", errorName: "E", message: "boom" }) + "\n",
+    );
+
+    expect(pending(root)).toHaveLength(1);
+    expect(pending(root)[0]!.occurrences).toBe(1);
+  });
 });
 
 describe("posted map", () => {

--- a/wiki-cli/test/report-store.test.ts
+++ b/wiki-cli/test/report-store.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, readdirSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  loadConfig,
+  saveConfig,
+  spool,
+  pending,
+  resolvePosted,
+  postedIssue,
+  clearSpool,
+  reportHome,
+  SPOOL_LIMIT,
+} from "../src/report/store.js";
+import type { Report } from "../src/report/model.js";
+
+let root: string;
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "report-store-"));
+});
+
+function report(over: Partial<Report> = {}): Report {
+  return {
+    schema: 1,
+    kind: "cli-error",
+    fingerprint: "aaaaaaaaaaaa",
+    command: "wiki note",
+    errorName: "ZodError",
+    message: "bad type",
+    version: "0.7.0",
+    platform: "darwin-arm64",
+    firstSeen: "2026-08-21T00:00:00.000Z",
+    lastSeen: "2026-08-21T00:00:00.000Z",
+    occurrences: 1,
+    ...over,
+  };
+}
+
+describe("consent resolution", () => {
+  it("defaults to unset — spool locally, post nothing", () => {
+    expect(loadConfig(root, {}).mode).toBe("unset");
+  });
+
+  it("reads an opted-in config", () => {
+    saveConfig(root, { mode: "auto" });
+    expect(loadConfig(root, {}).mode).toBe("auto");
+  });
+
+  it.each(["DO_NOT_TRACK", "DISABLE_TELEMETRY"])("%s forces off even when opted in", (key) => {
+    saveConfig(root, { mode: "auto" });
+    expect(loadConfig(root, { [key]: "1" }).mode).toBe("off");
+  });
+
+  it("ignores DO_NOT_TRACK=0", () => {
+    saveConfig(root, { mode: "auto" });
+    expect(loadConfig(root, { DO_NOT_TRACK: "0" }).mode).toBe("auto");
+  });
+
+  it("YMIR_REPORT=off overrides an opted-in config", () => {
+    saveConfig(root, { mode: "auto" });
+    expect(loadConfig(root, { YMIR_REPORT: "off" }).mode).toBe("off");
+  });
+
+  it("YMIR_REPORT=auto opts in without a config file", () => {
+    expect(loadConfig(root, { YMIR_REPORT: "auto" }).mode).toBe("auto");
+  });
+
+  it("survives a corrupt config rather than crashing the CLI", () => {
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, "config.json"), "{ not json");
+    expect(loadConfig(root, {}).mode).toBe("unset");
+  });
+});
+
+describe("destination repo", () => {
+  it("defaults upstream", () => {
+    expect(loadConfig(root, {}).repo).toBe("muitneliss/ymir");
+  });
+
+  it("honours a configured fork", () => {
+    saveConfig(root, { repo: "acme/ymir-internal" });
+    expect(loadConfig(root, {}).repo).toBe("acme/ymir-internal");
+  });
+
+  it("lets the environment win", () => {
+    saveConfig(root, { repo: "acme/ymir-internal" });
+    expect(loadConfig(root, { YMIR_REPORT_REPO: "other/repo" }).repo).toBe("other/repo");
+  });
+
+  it("rejects a malformed repo and falls back upstream", () => {
+    expect(loadConfig(root, { YMIR_REPORT_REPO: "not a repo" }).repo).toBe("muitneliss/ymir");
+  });
+});
+
+describe("spool", () => {
+  it("round-trips one report", () => {
+    spool(root, report());
+    const all = pending(root);
+    expect(all).toHaveLength(1);
+    expect(all[0]!.command).toBe("wiki note");
+  });
+
+  it("merges a recurrence instead of duplicating it", () => {
+    spool(root, report());
+    spool(root, report({ lastSeen: "2026-08-22T00:00:00.000Z" }));
+
+    const all = pending(root);
+    expect(all).toHaveLength(1);
+    expect(all[0]!.occurrences).toBe(2);
+    expect(all[0]!.firstSeen).toBe("2026-08-21T00:00:00.000Z");
+    expect(all[0]!.lastSeen).toBe("2026-08-22T00:00:00.000Z");
+  });
+
+  it("keeps distinct fingerprints apart", () => {
+    spool(root, report({ fingerprint: "aaaaaaaaaaaa" }));
+    spool(root, report({ fingerprint: "bbbbbbbbbbbb" }));
+    expect(pending(root)).toHaveLength(2);
+  });
+
+  it("caps the spool, evicting the least recently seen", () => {
+    for (let i = 0; i < SPOOL_LIMIT + 10; i++) {
+      spool(
+        root,
+        report({
+          fingerprint: String(i).padStart(12, "0"),
+          lastSeen: `2026-08-${String((i % 28) + 1).padStart(2, "0")}T00:00:00.000Z`,
+        }),
+      );
+    }
+    expect(pending(root).length).toBeLessThanOrEqual(SPOOL_LIMIT);
+  });
+
+  it("ignores a corrupt spool entry instead of failing the whole read", () => {
+    spool(root, report());
+    writeFileSync(join(root, "reports", "garbage.json"), "{{{");
+    expect(pending(root)).toHaveLength(1);
+  });
+
+  it("never throws when the home directory cannot be written", () => {
+    const locked = mkdtempSync(join(tmpdir(), "report-locked-"));
+    chmodSync(locked, 0o500);
+    expect(() => spool(join(locked, "nested"), report())).not.toThrow();
+    chmodSync(locked, 0o700);
+  });
+});
+
+describe("hook records", () => {
+  it("adopts JSONL dropped by a hook that cannot import the CLI", () => {
+    mkdirSync(join(root, "reports", "incoming"), { recursive: true });
+    writeFileSync(
+      join(root, "reports", "incoming", "hook.jsonl"),
+      JSON.stringify({
+        kind: "hook",
+        command: "ensure-wiki-binary",
+        errorName: "InstallError",
+        message: "sha256 mismatch",
+      }) + "\n",
+    );
+
+    const all = pending(root);
+    expect(all).toHaveLength(1);
+    expect(all[0]!.kind).toBe("hook");
+    expect(all[0]!.fingerprint).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  it("skips malformed JSONL lines", () => {
+    mkdirSync(join(root, "reports", "incoming"), { recursive: true });
+    writeFileSync(join(root, "reports", "incoming", "hook.jsonl"), "not json\n");
+    expect(pending(root)).toHaveLength(0);
+  });
+});
+
+describe("posted map", () => {
+  it("remembers the issue a fingerprint became, and clears the spool entry", () => {
+    spool(root, report());
+    resolvePosted(root, "aaaaaaaaaaaa", 42);
+
+    expect(postedIssue(root, "aaaaaaaaaaaa")).toBe(42);
+    expect(pending(root)).toHaveLength(0);
+  });
+
+  it("returns null for an unknown fingerprint", () => {
+    expect(postedIssue(root, "zzzzzzzzzzzz")).toBeNull();
+  });
+
+  it("survives the search-index lag that makes remote dedup unreliable", () => {
+    resolvePosted(root, "aaaaaaaaaaaa", 42);
+    spool(root, report());
+    expect(postedIssue(root, "aaaaaaaaaaaa")).toBe(42);
+  });
+});
+
+describe("clearSpool", () => {
+  it("removes every pending report", () => {
+    spool(root, report({ fingerprint: "aaaaaaaaaaaa" }));
+    spool(root, report({ fingerprint: "bbbbbbbbbbbb" }));
+    clearSpool(root);
+    expect(pending(root)).toHaveLength(0);
+  });
+
+  it("leaves the posted map intact so dedup still holds", () => {
+    resolvePosted(root, "aaaaaaaaaaaa", 42);
+    clearSpool(root);
+    expect(postedIssue(root, "aaaaaaaaaaaa")).toBe(42);
+  });
+});
+
+describe("reportHome", () => {
+  it("defaults under the user's home directory", () => {
+    expect(reportHome({ HOME: "/Users/alice" })).toBe("/Users/alice/.ymir");
+  });
+
+  it("honours YMIR_HOME", () => {
+    expect(reportHome({ HOME: "/Users/alice", YMIR_HOME: "/tmp/y" })).toBe("/tmp/y");
+  });
+});
+
+describe("flush window", () => {
+  it("is due when never flushed", () => {
+    expect(loadConfig(root, {}).lastFlushAt).toBeUndefined();
+  });
+
+  it("records the flush time", () => {
+    saveConfig(root, { lastFlushAt: "2026-08-21T00:00:00.000Z" });
+    expect(loadConfig(root, {}).lastFlushAt).toBe("2026-08-21T00:00:00.000Z");
+  });
+
+  it("preserves other fields when patching one", () => {
+    saveConfig(root, { mode: "auto", repo: "acme/x" });
+    saveConfig(root, { lastFlushAt: "2026-08-21T00:00:00.000Z" });
+
+    const cfg = loadConfig(root, {});
+    expect(cfg.mode).toBe("auto");
+    expect(cfg.repo).toBe("acme/x");
+  });
+});

--- a/wiki/SCHEMA.md
+++ b/wiki/SCHEMA.md
@@ -48,6 +48,13 @@ Run `... help` for the full command reference. Key commands:
   `--preview` reports the plan (link count, affected paths) without writing.
 - `reindex` — refresh the search index (creates the collection, or `qmd update`s it).
 - `query <q> [--limit <n>] [--chunks] [--verbatim] [--full|--snippet] [--context <chars>]` — search this wiki via qmd.
+- `report [--yes] [--off] [--flush] [--feedback <text>] [--skill --title <t> --detail <d>]` —
+  review and file Ymir self-reports. Command crashes are captured automatically to
+  `~/.ymir/`; with no flags this prints the exact issue text and sends nothing.
+  `--yes` files pending reports and opts in to automatic filing thereafter.
+  `--skill` records a failure of the Ymir skill flow that the CLI cannot observe.
+  Reports are redacted (paths, hostnames, credentials, identities) before storage.
+  Opt out with `--off`, `DO_NOT_TRACK=1`, `DISABLE_TELEMETRY=1`, or `YMIR_REPORT=off`.
 
 ## Page conventions
 - Cross-reference pages with `[[Exact Title]]`. The CLI validates every link target exists.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -25,6 +25,8 @@
 - [Ymir Harness Spec Design](sources/ymir-harness-spec-design.md)
 - [Ymir Harness Spec Plan](sources/ymir-harness-spec-plan.md)
 - [Ymir README](sources/ymir-readme.md)
+- [Ymir Self-Report Design](sources/ymir-self-report-design.md)
+- [Ymir Self-Report Plan](sources/ymir-self-report-plan.md)
 - [Ymir SKILL Dispatcher](sources/ymir-skill-dispatcher.md)
 - [Ymir Socratic Interview Design](sources/ymir-socratic-interview-design.md)
 - [Ymir Socratic Interview Plan](sources/ymir-socratic-interview-plan.md)

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -68,3 +68,10 @@
 ## [2026-08-18] ingest | Playbook Rules
 ## [2026-08-18] ingest | Socratic Interview Reference
 ## [2026-08-18] ingest | Ymir README
+## [2026-08-21] ingest | Ymir Self-Report Plan
+## [2026-08-21] ingest | Ymir Self-Report Design
+## [2026-08-21] ingest | Ymir Self-Report Plan
+## [2026-08-21] ingest | Wiki Schema
+## [2026-08-21] ingest | Ymir README
+## [2026-08-21] ingest | Ymir SKILL Dispatcher
+## [2026-08-21] note | Wiki CLI Command Surface

--- a/wiki/notes/wiki-cli-command-surface.md
+++ b/wiki/notes/wiki-cli-command-surface.md
@@ -1,14 +1,17 @@
 ---
 title: Wiki CLI Command Surface
 type: concept
-date: 2026-08-18
+date: 2026-08-21
 tags: []
 source_count: 0
 ---
 
 # Wiki CLI Command Surface
 
-The wiki CLI (`plugins/ymir/wiki-cli`, TypeScript/Node, built and tested with bun) is invoked as `wiki --root ./wiki <command>` and is the only sanctioned writer of the wiki. It is built on commander (parsing/help), a small js-yaml frontmatter module, remark (format), and zod (per-page-type frontmatter schema).
+The wiki CLI (`wiki-cli/` at the repo root, TypeScript/Node, built and tested with
+bun) is invoked as `wiki --root ./wiki <command>` and is the only sanctioned
+writer of the wiki. It is built on commander (parsing/help), a small js-yaml
+frontmatter module, remark (format), and zod (per-page-type frontmatter schema).
 
 Current commands:
 
@@ -25,6 +28,18 @@ Current commands:
 * `query <q> [--limit] [--chunks] [--verbatim] [--full|--snippet] [--context]` — search via qmd.
 * `fmt` — reformat all pages.
 * `init [--project-root] [--name]` — idempotently scaffold the entire wiki harness (see [[Init Scaffold Contract]]).
+* `report [--yes] [--off] [--flush] [--feedback <t>] [--skill --title <t> --detail <d>]` — review and file Ymir self-reports. With no flags it prints the exact issue body and sends nothing; `--yes` files pending reports and opts in to automatic filing thereafter; `--off` opts out and discards. See [[Ymir Self-Report Design]].
 * `help` — full command reference.
+* `--version` — the installed Ymir version, read from the `.version` stamp beside the executable.
 
-See [[Wiki Harness Design Spec]] for the original architecture, [[Wiki Schema]] for the in-wiki rules and command reference, [[Ymir SKILL Dispatcher]] for how the skill invokes the CLI, and [[Wiki Harness Model]] for the three-layer model this CLI enforces.
+Two conventions govern failures. Commands are pure functions returning
+`{text, exitCode}`, which is what lets tests drive them in-process rather than as
+subprocesses. And `cli.ts` wraps `parseAsync` in a single error boundary that
+prints one `error:` line: a `Rejection` — a predicted refusal such as a slug
+collision or broken link — stops there, while anything unpredicted is also
+captured as a self-report.
+
+See [[Wiki Harness Design Spec]] for the original architecture, [[Wiki Schema]] for
+the in-wiki rules and command reference, [[Ymir SKILL Dispatcher]] for how the
+skill invokes the CLI, and [[Wiki Harness Model]] for the three-layer model this
+CLI enforces.

--- a/wiki/sources/wiki-schema.md
+++ b/wiki/sources/wiki-schema.md
@@ -1,165 +1,42 @@
 ---
 title: Wiki Schema
 type: source
-date: 2026-08-18
+date: 2026-08-21
 tags: []
 source: wiki/SCHEMA.md
 source_path: wiki/SCHEMA.md
-source_hash: 8a446f542eb3038bf86ba07ce2a3ab9839c8254f760e9312091b0742a2cb462a
-ingested: 2026-08-18
+source_hash: 1e19daebf07ee95338fee0bf039811133a4c87da3e1786898e23c3fa378d40cd
+ingested: 2026-08-21
 ---
 
 # Wiki Schema
 
-# Wiki Schema & Rules
+The in-wiki rules and command reference for this project's LLM-maintained wiki.
 
-This wiki is an LLM-maintained knowledge base. **You (the LLM) never hand-write
-or hand-edit wiki documents.** All writes go through the Ymir wiki CLI, which
-formats and validates every change. Direct edits to `sources/`, `notes/`,
-`index.md`, and `log.md` are blocked by a PreToolUse hook.
+The LLM never hand-writes or hand-edits wiki documents. All writes go through the
+Ymir wiki CLI, which formats and validates every change; a PreToolUse hook blocks
+direct edits to `sources/`, `notes/`, `index.md` and `log.md`. Layers are `raw/`
+for external material, `sources/` for one CLI-written summary per ingested file,
+`notes/` for synthesis pages, plus the CLI-rebuilt `index.md` and CLI-appended
+`log.md`.
 
-## Layers
+The command reference covers `init`, `ingest` (tracked via `--source` with a
+recorded `source_path` and `source_hash`, or legacy `--raw`), `note`, `index`,
+`log`, `check` as the single CI gate, `validate`, `status`, `coverage`, `remove`,
+`rename`, `reindex`, `query` and `fmt`. It also documents `report`, which reviews
+and files Ymir self-reports: command crashes are captured automatically to
+`~/.ymir/`, `report` with no flags prints the exact issue text and sends nothing,
+`--yes` files pending reports and opts in to automatic filing, and `--skill`
+records a failure of the skill flow the CLI cannot observe itself. Reports are
+redacted before storage and disabled by `--off`, `DO_NOT_TRACK=1`,
+`DISABLE_TELEMETRY=1` or `YMIR_REPORT=off`.
 
-* `raw/` — for external content not tracked elsewhere in the repo (e.g. PDFs, exported snapshots). Use `ingest --raw <raw/path>` for these. Files that already live in the repo should be ingested with `ingest --source <path>` instead — that binds provenance to the living file and enables drift detection.
-* `sources/` — one CLI-written summary page per ingested source.
-* `notes/` — CLI-written entity / concept / topic pages (the synthesis).
-* `index.md` — CLI-rebuilt catalog. Never edit by hand.
-* `log.md` — CLI-appended timeline. Never edit by hand.
+Beyond commands it specifies page conventions and `[[Exact Title]]` linking,
+declarative source coverage via `wiki/tracked.yaml`, drift detection through
+content hashing surfaced by a SessionStart hook, and the qmd search setup —
+keyword-only BM25 over `sources/` and `notes/` with automatic reindexing on every
+write, where queries are reduced to content words because asking a question
+verbatim retrieves far worse.
 
-## The CLI
-
-Invoke via the bundled binary (`$SKILL_ROOT` is the Ymir skill root — the
-directory containing `SKILL.md`):
-
-```
-$SKILL_ROOT/wiki-cli/bin/wiki --root ./wiki <command>
-```
-
-Run `... help` for the full command reference. Key commands:
-
-* `ingest --source <path> --title <t>` (body on STDIN) — summarize a tracked file.
-  Records `source_path` + `source_hash` for drift detection.
-  Use `--raw <label>` (legacy) when ingesting from a non-tracked input.
-* `note --type entity|concept|topic --name <n>` (body on STDIN) — synthesis page.
-* `index` — rebuild the catalog.
-* `check [--json] [--error-on-orphan-notes] [--error-on-untracked-sources]` — single CI gate.
-  Evaluates schema validity, page identity, broken links, orphan policy, provenance drift,
-  untracked sources, declarative coverage, and index freshness in one read-only pass.
-  Exits non-zero on any hard failure; zero only when the wiki satisfies policy.
-  Orphan notes and untracked sources are warnings by default; promote to errors with the
-  respective flags. Use `--json` for machine-readable output with stable schema
-  `{ ok, errors[], warnings[] }`, each finding carrying `kind`, `message`, and `remedy`.
-* `validate` — health check (frontmatter, `[[links]]`, orphans, slug collisions, filename/title mismatches, nested pages).
-* `status` — show drift between source pages and their tracked files.
-  Use `--json` for machine-readable output (exit 1 if stale/missing).
-* `coverage` — verify declarative source coverage defined in `wiki/tracked.yaml`.
-  Fails when an in-scope file has no source page, an exclusion is stale, a file is
-  excluded yet ingested, a source page is out of scope, or multiple pages claim the
-  same file. Use `--json` for machine-readable output (exit 1 on any violation).
-* `remove --title <t> [--preview]` — atomically delete a page and rebuild all generated state.
-  Refuses if any page holds an inbound `[[link]]` to the target — fix those first.
-  `--preview` reports what would be removed and lists inbound links without writing.
-* `rename --old-title <t> --new-title <t> [--preview]` — rename a page, rewrite all inbound
-  `[[links]]`, and rebuild generated state atomically. Fails on slug collision.
-  `--preview` reports the plan (link count, affected paths) without writing.
-* `reindex` — refresh the search index (creates the collection, or `qmd update`s it).
-* `query <q> [--limit <n>] [--chunks] [--verbatim] [--full|--snippet] [--context <chars>]` — search this wiki via qmd.
-
-## Page conventions
-
-* Cross-reference pages with `[[Exact Title]]`. The CLI validates every link target exists.
-* Frontmatter is injected by the CLI — do not write it yourself.
-
-## Operations
-
-* **Ingest (tracked):** read the source file → call `ingest --source <path> --title <t>`
-  with the summary on STDIN → then update related `notes` via `note`.
-  The CLI records a sha256 hash so drift can be detected later.
-* **Ingest (raw):** user drops a file in `raw/` → read it → call
-  `ingest --raw <raw/path> --title <t>` (no drift tracking).
-* **Query:** call `query` → read returned pages → answer with citations →
-  optionally file the answer back as a `note`.
-* **CI gate:** run `check` (or `check --json`) → exits non-zero on any hard failure.
-  Add `--error-on-orphan-notes` or `--error-on-untracked-sources` to promote warnings to errors.
-* **Lint:** run `validate` → fix reported issues by issuing further CLI commands.
-* **Drift check:** run `status` → re-ingest stale pages with updated summaries.
-* **Coverage check:** run `coverage` → follow each violation's remedy to ingest missing files
-  or update `wiki/tracked.yaml`.
-* **Remove a page:** run `remove --title <t> --preview` to see inbound links and confirm no
-  breakage, then run `remove --title <t>` to delete the page and rebuild the index.
-  If inbound links exist, update or remove them first, then retry.
-* **Rename a page:** run `rename --old-title <t> --new-title <t> --preview` to see the scope
-  of link rewrites, then run `rename --old-title <t> --new-title <t>` to apply atomically.
-  All `[[old title]]` links in sources and notes are rewritten to `[[new title]]` in one step.
-
-## Source coverage (`wiki/tracked.yaml`)
-
-Create `wiki/tracked.yaml` to declare which project files the wiki must cover:
-
-```yaml
-include:
-  - "src/**/*.ts"
-  - "docs/**/*.md"
-exclude:
-  - pattern: "src/generated/**"
-    reason: "Auto-generated — not authored documentation"
-```
-
-* `include` — glob patterns relative to the project root. Every matching file that
-  is not excluded must have an ingested source page.
-* `exclude` — patterns with a mandatory `reason`. Each exclusion must match at least
-  one file (stale exclusions fail the check). A file that is excluded must not have
-  a source page.
-
-Run `wiki coverage` to verify. Each violation includes an actionable remedy.
-File discovery uses `git ls-files` so untracked scratch files in a worktree do not
-create false failures.
-
-## Auto-Sync (drift detection)
-
-A SessionStart hook runs `wiki status` at session start. If any source page is
-out of date (the tracked file changed since last ingest), it prints:
-
-```
-[ymir] Wiki out of date. Re-ingest these to match current files:
-  - page "Auth Module"  ← src/auth.ts (changed)
-For each: read the file, then run:
-  wiki --root ./wiki ingest --source <path> --title "<page title>"
-```
-
-Source pages that have no `source_hash` (ingested with `--raw`, or older pages)
-are "untracked" and never reported stale. You can ignore them or re-ingest with
-`--source` to opt them in to drift detection.
-
-## Search (qmd) setup
-
-Indexing is automatic: every `ingest`, `note`, and `index` calls `reindex`,
-which registers the collection on first use and `qmd update`s it thereafter. No
-manual setup step is needed; run `wiki reindex` yourself only to force a refresh.
-
-`wiki query "..."` shells out to `qmd search --json -c ymir-wiki`. The
-`-c` scope matters: without it qmd searches *every* collection registered on the
-machine, not just this project's wiki. Only `sources/` and `notes/` are indexed —
-`raw/` is deliberately excluded, since the raw originals outrank the curated
-summaries written from them. Use `--limit <n>` to cap results and `--chunks` to
-get every matching chunk rather than one entry per file.
-
-Search is keyword-only (BM25) — lightweight, no embeddings and no local LLM, so
-there is no `qmd embed` step. Because BM25 matches words rather than meaning,
-`query` first reduces your text to its content words: `"When did Melanie paint a
-sunrise?"` is searched as `melanie paint sunrise`. Asking a full question
-verbatim retrieves far worse (measured on a 19-page wiki: 0 hits vs 1, and 3
-hits vs 10). Pass `--verbatim` when you need the text exactly as typed.
-
-Each hit returns the passage around the match — whole paragraphs, bounded by the
-enclosing section — not a narrow window, so you can answer from the result
-without opening the file. A page smaller than the budget (`--context`, default
-3000 chars) comes back whole; longer pages are narrowed to the matching section.
-`--full` forces the entire page, `--snippet` gives qmd's raw window. Measured on
-this project's own wiki, answering from raw windows scored 43% where answering
-from expanded passages scored 93%.
-
-`ingest`, `note`, and `index` automatically call
-`wiki reindex` (best-effort) after each write; pass `--no-reindex` to skip.
-Run `wiki reindex` manually if the index is stale. Optional tighter integration:
-add a `qmd` MCP server (`qmd mcp`) to your client.
+See [[Wiki CLI Command Surface]] for the command set, [[Wiki Harness Model]] for
+the three-layer model, and [[Ymir Self-Report Design]] for the reporting design.

--- a/wiki/sources/ymir-readme.md
+++ b/wiki/sources/ymir-readme.md
@@ -1,117 +1,40 @@
 ---
 title: Ymir README
 type: source
-date: 2026-08-18
+date: 2026-08-21
 tags: []
 source: README.md
 source_path: README.md
-source_hash: 31433bb02bca522e74e98fec20d308cb9a52d92ef6461dd7db13d340300829ea
-ingested: 2026-08-18
+source_hash: 1e42ea494c67cb9c1e84ba990a19b2d872591fd676802118a135457821cda03d
+ingested: 2026-08-21
 ---
 
 # Ymir README
 
-![Ymir Logo](assets/ymir-minimal.svg)
+Ymir is a Claude Code plugin and agent skill that produces a harness spec for a
+repo — rules, lint, CI lint, wiki/context, and `CLAUDE.md`/`AGENT.md`. It never
+generates application code. It explores the codebase, runs a deep per-concern
+Socratic interview, re-audits for consistency, and emits
+`.ymir/harness-profile.yaml` plus `.ymir/harness-playbook.md`; `ymir apply` then
+generates the harness with backups, and `ymir revert` undoes the last apply.
 
-# Ymir
+Install either as a Claude Code plugin, which wires the hooks automatically, or
+as an agent skill via the skills CLI, which reaches Cursor and Codex too but
+needs the wiki binary bootstrapped once by hand.
 
-[![release-please](https://github.com/muitneliss/ymir/actions/workflows/release-please.yml/badge.svg)](https://github.com/muitneliss/ymir/actions/workflows/release-please.yml)
-[![release](https://img.shields.io/github/v/release/muitneliss/ymir?sort=semver)](https://github.com/muitneliss/ymir/releases)
-[![skills.sh](https://skills.sh/b/muitneliss/ymir)](https://skills.sh/muitneliss/ymir)
+The README documents the self-report contract. Because Ymir runs on the user's
+own machine, its failures are invisible upstream unless sent. A crash writes a
+redacted report to `~/.ymir/` and says so; nothing is transmitted until the user
+runs `wiki report --yes`, and `wiki report` alone prints the literal issue body
+for review. Reports carry the subcommand, error type and message, Ymir's version
+and the OS and architecture — paths, hostnames, email addresses, git remotes and
+credential-shaped strings are stripped before anything is stored, project paths
+keep only their relative tail, and no file contents or argument values are ever
+included. Delivery uses the user's own `gh` login, so the issue is filed by them
+and Ymir ships no credential; without `gh` a prefilled issue URL is printed
+instead. Opting out via `wiki report --off`, `DO_NOT_TRACK=1`,
+`DISABLE_TELEMETRY=1` or `YMIR_REPORT=off` stops capture entirely rather than
+merely withholding, and forks can redirect reports with `YMIR_REPORT_REPO`.
 
-A Claude Code plugin and agent skill that produces a **harness spec** for a
-repo — rules, lint, CI lint, wiki/context, and `CLAUDE.md`/`AGENT.md`.
-
-Ymir does **not** generate application code. It first **explores your codebase**,
-then runs a **deep Socratic interview** — per concern it probes the *why*,
-recommends a grounded option, and captures the rationale — re-audits for
-consistency, and emits a spec under `.ymir/`:
-
-* `.ymir/harness-profile.yaml` — your audited decisions (machine-readable).
-* `.ymir/harness-playbook.md` — step-by-step instructions an LLM follows to
-  generate the harness.
-
-You then generate the harness with `ymir apply`, which reads the spec and writes
-the real files (backing up anything it overwrites); `ymir revert` undoes the last
-apply. You can also drive generation by hand in a normal Claude Code session,
-guided by the spec.
-
-## Layout
-
-```
-ymir/
-├── .claude-plugin/
-│   └── marketplace.json        # the "ymir" marketplace
-└── plugins/
-    └── ymir/                   # the "ymir" plugin / skill
-        ├── .claude-plugin/
-        │   └── plugin.json
-        └── SKILL.md            # single dispatcher skill → /ymir
-```
-
-Ymir is one skill, not a fixed command list. Whatever you type after `ymir` is
-the intent; the skill interprets it and acts on the current project:
-
-```
-ymir init for this project
-ymir add lint for this project
-ymir add rules
-ymir set up CI
-ymir apply            # generate the harness from the spec
-ymir revert           # undo the last apply
-```
-
-## Install
-
-### Claude Code plugin (recommended for Claude Code users)
-
-```shell
-/plugin marketplace add muitneliss/ymir
-/plugin install ymir@ymir
-/reload-plugins
-```
-
-Then: `/ymir init for this project`
-
-The plugin marketplace installs via Claude Code's native plugin system, which
-wires up hooks automatically (including the wiki PreToolUse guard).
-
-### Agent skill via the skills CLI (Claude Code, Cursor, Codex, and others)
-
-```shell
-npx skills@latest add muitneliss/ymir
-```
-
-This installs Ymir as an agent skill under `.claude/skills/ymir/` (Claude Code)
-or the agent-specific equivalent. Distribution is purely git — `skills add` clones
-directly from this repo; there is no separate publish step.
-
-**One extra step for the wiki concern:** after `ymir apply`, if your harness
-includes the wiki concern, bootstrap the wiki binary once:
-
-```shell
-node "$SKILL_ROOT/hooks/ensure-wiki-binary.mjs"
-"$SKILL_ROOT/wiki-cli/bin/wiki" --root ./wiki init --no-hook
-```
-
-(`$SKILL_ROOT` is the directory where the skill was installed, e.g.
-`.claude/skills/ymir/` for Claude Code.)
-
-**Telemetry:** the skills CLI collects anonymous usage telemetry.
-Set `DISABLE_TELEMETRY=1` or `DO_NOT_TRACK=1` to opt out.
-
-## Status
-
-`v0.6.0`. Ymir runs a codebase-first flow: it scans the repo, then runs a deep
-per-concern Socratic interview (probe *why* → recommend → confirm, capturing
-`why`/`findings`), a consistency + reflection gate, a spec-review gate, and a spec
-emitted to `.ymir/` (`harness-profile.yaml` + `harness-playbook.md`); `ymir apply`
-then generates the harness from that spec (with backups + `ymir revert`). The
-spec's per-concern playbook sections live in `plugins/ymir/templates/playbook/`;
-the interview engine is in `plugins/ymir/references/socratic-interview.md`. The
-**rules** concern emits native `.claude/rules/*.md` for Claude Code targets, or
-embeds rules inline in `AGENT.md` for agent-neutral harnesses. The **wiki / context**
-section drives the bundled wiki tooling (`plugins/ymir/wiki-cli`, templates, and
-the PreToolUse hook for Claude Code or a CI gate for other agents). The harness
-profile records `target_agent` (claude-code or any) so every concern generates
-the right output for the chosen agent.
+See [[Ymir SKILL Dispatcher]] for the skill flow, [[Ymir Self-Report Design]] for
+the reporting architecture, and [[Wiki Schema]] for the wiki CLI rules.

--- a/wiki/sources/ymir-self-report-design.md
+++ b/wiki/sources/ymir-self-report-design.md
@@ -1,0 +1,50 @@
+---
+title: Ymir Self-Report Design
+type: source
+date: 2026-08-21
+tags: []
+source: docs/superpowers/specs/2026-08-21-ymir-self-report-design.md
+source_path: docs/superpowers/specs/2026-08-21-ymir-self-report-design.md
+source_hash: b60ec79e2e497aaedcb9ef9b89f924ab6f6a58cdb1482247ea7eb0f8c335524d
+ingested: 2026-08-21
+---
+
+# Ymir Self-Report Design
+
+Design for capturing Ymir's failures on end-user machines and filing them as
+deduplicated GitHub issues.
+
+The problem is that Ymir ships to other people's machines, so its failures are
+invisible upstream. The failure experience made this worse: `cli.ts` ended in a
+bare `program.parseAsync()` with no top-level handler, so any async throw escaped
+as an unhandled rejection — measured on the shipped compiled binary, an invalid
+`--type` produced an eleven-line ZodError dump and no stack frames at all,
+because `bun build --compile` emits none.
+
+Key decisions. Consent is opt-in once then automatic, defaulting to off, honoring
+`DO_NOT_TRACK`, `DISABLE_TELEMETRY` and `YMIR_REPORT=off`; when off, nothing is
+captured at all rather than captured-but-withheld. The crash path only writes to
+disk, never the network, so a crashing CLI cannot also hang on `gh`. Delivery is
+an opportunistic flush inside the CLI rather than a SessionStart hook, which adds
+no payload file and still works for skills-CLI installs on non-Claude agents.
+Identity is a fingerprint over kind, command, error name and digit-normalized
+message, deliberately excluding the stack because compiled frames are
+build-specific offsets. Dedup consults a local fingerprint-to-issue map before
+any GitHub search, because the search index trails issue creation and a
+search-first design would file duplicates for the length of the lag.
+
+Five units live inside the wiki CLI so the plugin payload is unchanged: a pure
+redactor, the report model, the `~/.ymir` store, the `gh` delivery layer modeled
+on `reindex.ts`'s never-throwing subprocess pattern, and a facade plus command.
+Redaction runs before fingerprinting, which keeps the spool safe to read and
+makes one bug fingerprint identically on every machine.
+
+The error boundary reports only what it did not predict. Building it surfaced two
+root-cause bugs it would otherwise have papered over: `note --type` threw a raw
+ZodError for plain user error, and the `"<command> rejected:"` message-prefix
+convention gave callers no way to tell a refusal from a crash except by matching
+text — now a `Rejection` type.
+
+See [[Ymir Self-Report Plan]] for the implementation sequence,
+[[Wiki CLI Command Surface]] for the command it adds, and [[Ymir README]] for the
+user-facing contract.

--- a/wiki/sources/ymir-self-report-plan.md
+++ b/wiki/sources/ymir-self-report-plan.md
@@ -1,0 +1,41 @@
+---
+title: Ymir Self-Report Plan
+type: source
+date: 2026-08-21
+tags: []
+source: docs/superpowers/plans/2026-08-21-ymir-self-report.md
+source_path: docs/superpowers/plans/2026-08-21-ymir-self-report.md
+source_hash: 830dba31841954535b4629f2aa46b6ac98335b514ad06784e4ce5b94eef6494c
+ingested: 2026-08-21
+---
+
+# Ymir Self-Report Plan
+
+Test-driven implementation sequence for Ymir's self-report, in eight units, each
+written red before the implementation existed.
+
+Unit 1 is the redactor (32 tests): credentials first so a token buried in a path
+or query dies whatever encloses it, then identities, then paths last because they
+are greediest. A non-allowlisted URL is replaced whole, since an internal
+hostname names an employer as surely as a home directory names a user. Unit 2 is
+the model and fingerprint, reusing the existing `sha256Hex`. Unit 3 is the
+`~/.ymir` store, where every path degrades rather than throwing, including an
+unwritable home directory. Unit 4 is delivery, hermetic via an injected
+`GhRunner` so no test touches the network. Unit 5 is the facade and the
+`wiki report` command, returning `{text, exitCode}` to match `runStatus`.
+
+Unit 6 is the error boundary, which also fixed `note --type` to validate rather
+than throw a raw ZodError, and isolated the note tests from qmd reindex as an
+earlier change had for ingest — the suite went from 51 seconds with three
+timeouts to under 5 seconds green. Unit 7 moves the seven duplicated
+`stderr` + `exit(2)` sites in the install hook into one `bail()` that also
+appends a JSONL record. Unit 8 is documentation.
+
+Verification covered the compiled binary, not just the source: the old ZodError
+dump is now one line, four repeated crashes merge into one record with an
+occurrence count, opt-out discards and halts capture, `DO_NOT_TRACK` creates no
+state at all, and an adversarial payload carrying a real username, a token, an
+email, a secret query value and an internal hostname leaked none of them.
+
+See [[Ymir Self-Report Design]] for the rationale and [[Wiki CLI Command Surface]]
+for the resulting command set.

--- a/wiki/sources/ymir-skill-dispatcher.md
+++ b/wiki/sources/ymir-skill-dispatcher.md
@@ -1,293 +1,45 @@
 ---
 title: Ymir SKILL Dispatcher
 type: source
-date: 2026-08-18
+date: 2026-08-21
 tags: []
 source: plugins/ymir/SKILL.md
 source_path: plugins/ymir/SKILL.md
-source_hash: 69241e07617ef567f36cfd04d811c48f1545696ba7fb20c3b4d7b02b5c3c79b5
-ingested: 2026-08-18
+source_hash: f9b11b2bf987886213aa575a410f25864de9694ee7c97c6977961e25fbef3cea
+ingested: 2026-08-21
 ---
 
 # Ymir SKILL Dispatcher
 
-***
-
-name: ymir
-description: Ymir explores THIS project's codebase (the current working directory), then runs a deep Socratic interview across a harness checklist, re-audits for completeness + consistency, and emits a SPEC under .ymir/ (the interview step writes only the spec). The spec covers rules, lint, CI lint, wiki/context, and CLAUDE.md/AGENT.md; 'ymir apply' then generates the harness from the spec (with backups + 'ymir revert'). Use whenever the user asks Ymir to do something to the project, e.g. "ymir init for this project", "ymir add lint", "ymir add rules", "ymir set up CI", "ymir apply", "ymir revert", "scaffold the harness", "bootstrap this repo".
-argument-hint: "init | add lint | add rules | add ci | add context | add claude.md | apply [concern] | revert — what to do for this project"
----------------------------------------------------------------------------------------------------------------------------------------------
-
-# Ymir
-
-Ymir produces a **harness spec** for the current project — never application code.
-The *interview* step writes only the spec; `ymir apply` is the separate, explicit
-step that generates the harness files from that spec. The foundation it generates
-steers Claude Code:
-
-1. **rules** — coding standards / conventions
-2. **lint** — linter config for the chosen stack
-3. **CI lint** — a CI workflow that runs the linter
-4. **wiki / context** — a place for project knowledge
-5. **CLAUDE.md / AGENT.md** — the file that steers Claude Code on this repo
-
-The deliverable is two files under `.ymir/`:
-
-* `.ymir/harness-profile.yaml` — the audited decisions (machine-readable).
-* `.ymir/harness-playbook.md` — step-by-step generation instructions for an LLM.
-
-**The interview step writes only these two files.** Generating the actual rules
-docs, lint configs, CI workflows, wiki, or `CLAUDE.md` happens when you run
-`ymir apply` (see "Applying the spec" below) — not during the interview.
-
-## How this skill works
-
-This is a single dispatcher. The user's words after `ymir` are the intent
-(`$ARGUMENTS`) — interpret them and act on **this project** (cwd). Map the intent
-to the checklist of harness concerns above. Examples:
-
-| User says                            | Intent                                                                                                                                                             |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ymir init for this project`         | understand the codebase, sweep the checklist, audit, emit the spec                                                                                                 |
-| `ymir add lint for this project`     | interview + audit only the `lint` concern; update the spec                                                                                                         |
-| `ymir add rules`                     | interview + audit only `rules`; update the spec                                                                                                                    |
-| `ymir set up CI`                     | interview + audit only `ci`; update the spec                                                                                                                       |
-| `ymir add context` / `ymir add wiki` | **scaffold the wiki directly** — execute the existing wiki flow (the one exception to spec-only); see "Wiki-only intent" below                                     |
-| `ymir apply`                         | generate the harness from the spec: preview → confirm → per concern (keep/merge/overwrite, backing up first) → verify all → summary; see "Applying the spec" below |
-| `ymir apply lint` (or any concern)   | apply only that one concern from the spec                                                                                                                          |
-| `ymir revert`                        | restore the files the most recent `ymir apply` overwrote/merged, from `*.backup.<run-id>`; see "Reverting an apply" below                                          |
-| anything ambiguous                   | ask a short clarifying question, then proceed                                                                                                                      |
-
-If `$ARGUMENTS` is empty, treat it as `init`. If `.ymir/harness-profile.yaml`
-already exists, read it first and ask only what is missing or requested
-(idempotent / resumable).
-
-### Wiki-only intent (the one exception to spec-only)
-
-If — and only if — the intent is explicitly to create the wiki
-(`ymir add context`, `ymir add wiki`), Ymir **executes** the wiki scaffold
-immediately against the project via **a single CLI call** — never by hand-editing
-files. The CLI owns the tree, the PreToolUse hook, the `.claude/settings.json`
-entry, the `CLAUDE.md` block, and the validation step.
-
-All asset paths below (`references/`, `templates/`, `wiki-cli/`, `hooks/`) are
-**relative to this skill's root directory** — the directory that contains this
-`SKILL.md`. Resolve `$SKILL_ROOT` as that directory before running any command
-(`CLAUDE_PLUGIN_ROOT` holds it in Claude Code plugin installs; derive it from this
-file's path for skills-CLI installs).
-
-Provision the wiki binary once (idempotent), then scaffold from the project root:
-
-```bash
-node "$SKILL_ROOT/hooks/ensure-wiki-binary.mjs"
-"$SKILL_ROOT/wiki-cli/bin/wiki" --root ./wiki init
-```
-
-It is idempotent (safe to re-run); on success the last line is `wiki valid`. If it
-errors, stop and report. Then tell the user the qmd one-time setup (also in
-`wiki/SCHEMA.md`): `qmd collection add ./wiki --name <project>-wiki`. Search is
-keyword-only (BM25) — no `qmd embed`; re-run `qmd collection add` to refresh after
-adding pages. This is the only case where Ymir writes project files.
-
-For any broader intent (`ymir init`, or any other concern), Ymir stays spec-only:
-the wiki is captured in the profile and written into `harness-playbook.md` as the
-`wiki` section, and generation happens downstream.
-
-## The checklist
-
-The interview and the audit are driven by this checklist — one foundation item
-plus the five concerns:
-
-| # | Item                 | Drives                                                      |
-| - | -------------------- | ----------------------------------------------------------- |
-| 0 | project / techstack  | language, runtime, layer (frontend/backend/both), repo host |
-| 1 | rules                | conventions to obey / patterns to avoid                     |
-| 2 | lint                 | linter tool, strictness, style                              |
-| 3 | CI lint              | CI provider, what it runs                                   |
-| 4 | wiki / context       | enabled?, collection name                                   |
-| 5 | CLAUDE.md / AGENT.md | steering points (derived from 1–4)                          |
-
-## Step 0 — Understand the project (codebase-first)
-
-Before asking anything, scan the repo and build a **gap report**. Detect the
-foundation (language, runtime, layer, host) from manifests (`package.json`,
-`go.mod`, `pyproject.toml`, …), lockfiles, and the `.git` remote; and per concern
-detect current state + a verdict — `present-strong`, `present-weak`, or `missing`:
-
-* `rules`: existing `.claude/rules/*.md`, conventions docs, `.editorconfig`, a
-  `CLAUDE.md`/`AGENT.md` rules section.
-* `lint`: a linter config present? which tool? strict?
-* `ci`: workflows present? what do they run?
-* `wiki`: a docs/context/wiki dir already used for project knowledge?
-* `claude_md`: `CLAUDE.md`/`AGENT.md` present? what does it steer?
-
-Print a one-line-per-concern findings summary so the interview is visibly
-grounded. **Greenfield fallback:** if there are no usable signals, mark every
-concern `missing` and proceed to ask cold.
-
-## Step 1 — Per-concern Socratic interview
-
-Walk item 0 (techstack — mostly **confirm** what Step 0 detected) then each
-in-scope concern. For each concern run the 4-move engine — **probe why → recommend
-(2-3 trade-offs, recommendation first) → adaptive follow-up only when needed →
-confirm** — asking **one question per `AskUserQuestion` message**. The full engine,
-the per-concern probe bank, the rules scope-probing, and the greenfield phrasing
-live in `references/socratic-interview.md` (relative to the skill root) — read it before
-interviewing.
-
-* For `ymir init`, sweep the whole checklist; for a narrow action (e.g. `add
-  lint`), run item 0 (if unknown) plus that one concern.
-* The user may skip a concern → record `status: skipped` with a `reason`.
-* Write each answer into `.ymir/harness-profile.yaml` as you go, including
-  `why`, `findings`, and `alternatives_considered`. Field shape:
-  `templates/harness-profile.schema.md` (relative to the skill root).
-
-## Step 2 — Consistency + re-audit (gate)
-
-Before emitting:
-
-1. **Required-field check** — every in-scope concern has its decision fields plus
-   `why` and `findings`. Anything missing → keep the concern `pending` and loop
-   back to ask exactly that.
-2. **Cross-concern consistency pass** — run the bounded checklist in
-   `references/socratic-interview.md` ("Cross-concern consistency checklist"). On a
-   conflict, surface it plainly and **go back** to re-ask the implicated concern.
-3. **Reflection gate** — print, per concern, `decision + one-line why` (with
-   `✅ captured` / `⏭️ skipped` / `❌ pending` markers) and ask: *"Does this reflect
-   your intent? Want to revisit any concern before I write the spec?"*
-
-**Do not proceed to Step 3 while any in-scope concern is `pending`, or before the
-user confirms the reflection summary.**
-
-## Step 3 — Emit the spec
-
-Assemble the playbook from the bundled per-concern templates — do not free-form it:
-
-1. Ensure `.ymir/harness-profile.yaml` reflects the final audited decisions
-   (`spec_version: 2`).
-2. Write `.ymir/harness-playbook.md`: start from
-   `templates/playbook/header.md` (fill `{{PROJECT}}` and
-   `{{DATE}}`), then append one section per `captured` concern from
-   `templates/playbook/<concern>.md`, filling every `{{...}}`
-   placeholder (including the `Why / Findings` block) from the profile. Omit
-   `skipped` concerns.
-3. Tell the user the spec is ready under `.ymir/`.
-
-(Spec-generation only — never write harness files here; `ymir apply` does that.)
-
-## Step 4 — Spec-review gate
-
-After emitting, before offering apply, ask the user to review the written files:
-
-> "Spec written to `.ymir/harness-profile.yaml` and `.ymir/harness-playbook.md`.
-> Please review them and tell me if you want any changes before I generate the
-> harness."
-
-Wait. On a change request, revisit the relevant concern, re-emit, and return to
-this gate. Only on approval proceed to Step 5.
-
-## Step 5 — Offer to apply (the full flow is init → apply)
-
-After the user approves the spec, **ask** (via `AskUserQuestion`) whether to
-generate it now:
-
-> "Generate the harness now with `ymir apply`?"
-
-* **Yes** → proceed into the "Applying the spec" flow below, in this same session.
-* **No** → tell the user they can run `ymir apply` whenever they're ready; stop here.
-
-For a narrow intent (e.g. `ymir add lint`), offer `ymir apply lint` — apply just
-that one concern. Never auto-run apply without a yes; apply writes files.
-
-## Applying the spec — `ymir apply` (writes the harness)
-
-`ymir apply` is the explicit, user-triggered step that turns the spec into real
-harness files. It never invents a spec: if `.ymir/harness-profile.yaml` or
-`.ymir/harness-playbook.md` is missing, stop and tell the user to run `ymir init`
-first.
-
-**Scope.** `ymir apply` applies every `captured` concern in the profile.
-`ymir apply <concern>` (e.g. `ymir apply lint`) applies only that concern.
-
-**1 — Load + preview.** Read the profile and the playbook. For each in-scope
-concern, read its `**Target:**` line from the playbook section to learn the
-artifact (a literal path, a directory like `.claude/rules/`, or a tool/provider-derived
-one such as the linter config for `concerns.lint.tool` or a workflow under
-`.github/workflows/`). Test whether that artifact already exists and print a plan
-table:
-
-| Concern | Target              | State   | Planned action           |
-| ------- | ------------------- | ------- | ------------------------ |
-| rules   | `.claude/rules/`    | missing | create                   |
-| lint    | `eslint.config.mjs` | exists  | ask keep/merge/overwrite |
-| wiki    | `wiki/`             | missing | create                   |
-
-**2 — Confirm once.** Ask the user to confirm the whole plan a single time before
-writing anything.
-
-**3 — Capture a run-id.** Capture one timestamp for the entire run:
-`run_id=$(date +%Y%m%d%H%M%S)`. Every backup this run makes reuses this same
-`run_id` so `ymir revert` can restore them as one group.
-
-**4 — Execute each in-scope concern**, in playbook order:
-
-* **Target missing** → generate it by following that concern's playbook Steps.
-* **Target exists** → ask **keep / merge / overwrite** (`AskUserQuestion`):
-  * *keep* → write nothing.
-  * *merge* → `cp "<file>" "<file>.backup.$run_id"`, then fold the spec-driven
-    changes into the existing file, guided by the playbook Steps.
-  * *overwrite* → `cp "<file>" "<file>.backup.$run_id"`, then write the freshly
-    generated artifact.
-* **Directory target (e.g. `.claude/rules/`)** → treat each file in it as its own
-  artifact: test existence, ask keep/merge/overwrite, and back up **per file**
-  (`cp "<file>" "<file>.backup.$run_id"`) so `ymir revert` restores them
-  individually.
-* **Rule:** back up **before** any overwrite or merge; never back up a file you
-  are creating fresh.
-
-**5 — Verify all.** Run **every** in-scope concern's `**Verify:**` step. Do **not**
-stop on the first failure — run them all and collect the results.
-
-**6 — Summary table.** Print one row per concern and finish with the revert hint:
-
-| Concern | Result                       |
-| ------- | ---------------------------- |
-| rules   | ✅ generated + verified       |
-| lint    | ⏭️ kept (existing)           |
-| ci      | 🔁 merged + verified         |
-| wiki    | ❌ verify failed — `<reason>` |
-
-End by telling the user: `ymir revert` undoes this run (run-id `<run_id>`).
-
-## Reverting an apply — `ymir revert`
-
-`ymir revert` restores the files the most recent `ymir apply` overwrote or merged.
-
-1. **Find the latest run-id.** List backups under the project and take the
-   greatest `<run-id>` suffix (timestamps sort lexically):
-   ```bash
-   find . -name '*.backup.*' 2>/dev/null | sed 's/.*\.backup\.//' | sort -u | tail -1
-   ```
-2. **Restore each backup of that run-id:** for every `<file>.backup.<run-id>`, run
-   `mv "<file>.backup.<run-id>" "<file>"` (overwriting the applied version).
-3. **Report** which files were restored.
-
-**Limitation (by design — no manifest):** revert only restores files that have a
-`.backup.<run-id>` — i.e. ones apply overwrote or merged. Files apply created from
-scratch have no backup; they remain and show up in `git status`. Remove them
-manually or with `git clean` for a full undo.
-
-## Boundaries
-
-* Operate on the current project only ("this project" = cwd).
-* **Spec generation is spec-only.** The interview intents (`ymir init`,
-  `ymir add <concern>`) write only `.ymir/harness-profile.yaml` and
-  `.ymir/harness-playbook.md`. Two intents write harness files on purpose:
-  `ymir apply` (generates the harness from the spec, with backups) and
-  `ymir revert` (restores those backups). The wiki-only shortcut
-  (`ymir add context` / `ymir add wiki`) also executes directly; `ymir apply wiki`
-  reaches the same result through the general apply path.
-* Prefer asking over assuming — but ground the asking in what the codebase
-  actually shows (Step 0). The interview is the source of truth.
-* The `rules` concern emits native `.claude/rules/*.md` (path-scoped), not a
-  `docs/rules.md`; `CLAUDE.md` does not point at them (auto-discovered).
+The single dispatcher skill that interprets whatever the user types after `ymir`
+as intent and acts on the current project. It produces a harness spec, never
+application code.
+
+The interview step writes only `.ymir/harness-profile.yaml` and
+`.ymir/harness-playbook.md`. Step 0 scans the repo and prints a per-concern gap
+report; Step 1 runs the four-move Socratic engine per concern, one question per
+message; Step 2 gates on required fields, cross-concern consistency and a
+reflection summary; Step 3 assembles the playbook from bundled templates; Step 4
+is a spec-review gate; Step 5 offers to apply.
+
+`ymir apply` is the separate explicit step that generates the harness: load and
+preview a plan table, confirm once, capture a run-id, then per concern create or
+ask keep/merge/overwrite while backing up first, verify every concern, and print
+a summary. `ymir revert` restores that run's backups, with the documented
+limitation that files created from scratch have no backup. The wiki-only intents
+`ymir add context` and `ymir add wiki` are the one exception that writes project
+files directly, via a single CLI call.
+
+The skill also carries the self-report protocol. The wiki CLI captures its own
+crashes unaided; what it cannot see is this skill's flow breaking — a playbook
+section missing its Target line, an apply that writes nothing, an instruction
+that contradicts itself. Claude records those with `wiki report --skill`, after
+telling the user, describing rather than pasting so the user's code and profile
+values never enter the report, reporting Ymir's faults rather than the user's
+choices, once per session, and noting that nothing leaves the machine until the
+user opts in. Feature requests and complaints go through `wiki report --feedback`.
+
+See [[Ymir README]] for install and the user-facing contract,
+[[Socratic Interview Flow]] for the interview engine,
+[[Harness Playbook Model]] for the spec shape, and [[Ymir Self-Report Design]] for
+the reporting architecture.


### PR DESCRIPTION
Ymir ships to other people's machines, so its failures are invisible to us unless someone reports them by hand. This adds a self-report path: capture a failure, redact it, and file it as a deduplicated issue on this repo.

## The bug that motivated it

`wiki-cli/src/cli.ts` ended in a bare `program.parseAsync()` with **no top-level handler**, so every async failure escaped as an unhandled rejection. Against the shipped compiled binary:

```
$ wiki --root ./wiki note --type bogus --name P
ZodError: [ { "code": "invalid_value", ... } ]     # 11 lines of JSON
Bun v1.3.14 (macOS arm64)
```

No `error:` prefix, no guidance, and **no stack frames at all** — `bun build --compile` emits none. Now:

```
$ wiki --root ./wiki note --type bogus --name P
error: --type must be one of entity|concept|topic (got "bogus")
```

## Design

- **Consent**: opt in once, automatic after. Default **off**. Honors `DO_NOT_TRACK`, `DISABLE_TELEMETRY`, `YMIR_REPORT=off`. When off, nothing is captured *at all* — not captured-and-withheld.
- **Crash path never touches the network.** A crash spools to `~/.ymir/`; delivery happens later via an opportunistic flush. A crashing CLI must not also hang on `gh`.
- **No shipped credential.** Delivery borrows the user's own `gh` login; without it, a prefilled `issues/new?…` URL.
- **Fingerprint excludes the stack** — compiled frames are build-specific offsets, so a stack-based identity is unstable or empty in exactly the builds users run.
- **Redact before fingerprint.** Otherwise each user's home directory folds into the identity and one bug arrives as a fresh issue from every person who hits it.
- **Dedup local-first.** GitHub's search index trails creation; a search-first design would file duplicates for the length of the lag.
- **No new payload file** — the installed skill stays at 13 files (CI budget 20). An opportunistic flush also works for `skills add` installs on Codex/Cursor, where Claude Code hooks never run.

## Two root-cause fixes this surfaced

- `note --type` threw a raw `ZodError` for plain user error → now validates and prints one line.
- The `"<command> rejected:"` message-prefix convention gave callers no way to tell a refusal from a crash except by matching text → now a `Rejection` type. Without this, every broken `[[link]]` would file a bug report.

## Verification

400 tests, 0 fail (was 387 pass / 3 fail — also isolates `note.test.ts` from qmd reindex as #57 did for ingest; suite went 51s → 5s).

Checked against a real `bun --compile` binary: four repeated crashes merge to one record with `occurrences: 4`; opt-out discards and halts capture; `DO_NOT_TRACK` creates no state at all; no `gh` yields a working URL.

Adversarial redaction pass — a payload with a real username, a `ghp_` token, an email, a secret query value and an internal hostname leaked **none** of them.

Test fixtures assemble credential-shaped strings at runtime; no such literal exists in the source or in this branch's history.

## What a report contains

Subcommand, error name, redacted message/stack, flag *names*, version, OS/arch. Never argument values or file contents. Project paths keep only their relative tail (`<project>/src/auth.ts`); everything else becomes `<path>/name`.

Docs updated in README, SKILL.md, SCHEMA.md and `wiki help`, with a design doc and plan under `docs/superpowers/`, all ingested into the wiki (`wiki check` passes).