### PR TITLE
docs: install via the skills CLI only, and fix a binary-install race

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 [![release](https://img.shields.io/github/v/release/muitneliss/ymir?sort=semver)](https://github.com/muitneliss/ymir/releases)
 [![skills.sh](https://skills.sh/b/muitneliss/ymir)](https://skills.sh/muitneliss/ymir)
 
-A Claude Code plugin and agent skill that produces a **harness spec** for a
-repo — rules, lint, CI lint, wiki/context, and `CLAUDE.md`/`AGENT.md`.
+An agent skill that produces a **harness spec** for a repo — rules, lint, CI
+lint, wiki/context, and `CLAUDE.md`/`AGENT.md`. Works with Claude Code, Cursor,
+Codex, and any other agent the [skills CLI](https://skills.sh) supports.
 
 Ymir does **not** generate application code. It first **explores your codebase**,
 then runs a **deep Socratic interview** — per concern it probes the *why*,
@@ -20,21 +21,26 @@ consistency, and emits a spec under `.ymir/`:
 
 You then generate the harness with `ymir apply`, which reads the spec and writes
 the real files (backing up anything it overwrites); `ymir revert` undoes the last
-apply. You can also drive generation by hand in a normal Claude Code session,
-guided by the spec.
+apply. You can also drive generation by hand in a normal agent session, guided by
+the spec.
 
 ## Layout
 
 ```
 ymir/
-├── .claude-plugin/
-│   └── marketplace.json        # the "ymir" marketplace
-└── plugins/
-    └── ymir/                   # the "ymir" plugin / skill
-        ├── .claude-plugin/
-        │   └── plugin.json
-        └── SKILL.md            # single dispatcher skill → /ymir
+├── plugins/
+│   └── ymir/                   # the installed skill payload
+│       ├── .claude-plugin/
+│       │   └── plugin.json     # version, propagated by release-please
+│       ├── SKILL.md            # single dispatcher skill
+│       ├── hooks/              # binary provisioning + wiki drift check
+│       ├── references/         # the Socratic interview engine
+│       └── templates/          # per-concern playbook sections
+└── wiki-cli/                   # source for the bundled `wiki` binary
 ```
+
+`skills add` installs the `plugins/ymir/` tree; `wiki-cli/` stays out of the
+payload and ships as a compiled release binary instead.
 
 Ymir is one skill, not a fixed command list. Whatever you type after `ymir` is
 the intent; the skill interprets it and acts on the current project:
@@ -50,39 +56,66 @@ ymir revert           # undo the last apply
 
 ## Install
 
-### Claude Code plugin (recommended for Claude Code users)
-
-```shell
-/plugin marketplace add muitneliss/ymir
-/plugin install ymir@ymir
-/reload-plugins
-```
-
-Then: `/ymir init for this project`
-
-The plugin marketplace installs via Claude Code's native plugin system, which
-wires up hooks automatically (including the wiki PreToolUse guard).
-
-### Agent skill via the skills CLI (Claude Code, Cursor, Codex, and others)
+Ymir installs as an agent skill via the [skills CLI](https://skills.sh), which
+works with Claude Code, Cursor, Codex, and others:
 
 ```shell
 npx skills@latest add muitneliss/ymir
 ```
 
-This installs Ymir as an agent skill under `.claude/skills/ymir/` (Claude Code)
-or the agent-specific equivalent. Distribution is purely git — `skills add` clones
-directly from this repo; there is no separate publish step.
+Add `--global` to install for every project rather than just the current one:
 
-**One extra step for the wiki concern:** after `ymir apply`, if your harness
-includes the wiki concern, bootstrap the wiki binary once:
+```shell
+npx skills@latest add muitneliss/ymir --global
+```
+
+Then just say what you want: `ymir init for this project`.
+
+The skill lands in `~/.claude/skills/ymir/` (or the project-local
+`.claude/skills/ymir/`, or your agent's equivalent). Distribution is purely git —
+`skills add` clones straight from this repo, so there is no separate publish step
+and no registry account.
+
+Upgrade and remove with the same tool:
+
+```shell
+npx skills@latest update ymir
+npx skills@latest remove ymir
+```
+
+### The wiki binary
+
+The `wiki` CLI is a compiled binary fetched from this repo's GitHub Releases on
+first use, matched to the installed version and verified against a published
+SHA256. Under Claude Code this happens automatically at session start. On other
+agents, or to fetch it ahead of time, run it yourself once:
 
 ```shell
 node "$SKILL_ROOT/hooks/ensure-wiki-binary.mjs"
+```
+
+(`$SKILL_ROOT` is where the skill was installed — e.g. `~/.claude/skills/ymir/`.)
+
+If your harness includes the wiki concern and your agent is not Claude Code, also
+scaffold the wiki without the Claude-specific hook:
+
+```shell
 "$SKILL_ROOT/wiki-cli/bin/wiki" --root ./wiki init --no-hook
 ```
 
-(`$SKILL_ROOT` is the directory where the skill was installed, e.g.
-`.claude/skills/ymir/` for Claude Code.)
+### Migrating from the Claude Code plugin
+
+Earlier versions were distributed as a Claude Code plugin. That path is retired;
+the skills CLI covers Claude Code too. To switch:
+
+```shell
+claude plugin uninstall ymir@ymir
+claude plugin marketplace remove ymir
+npx skills@latest add muitneliss/ymir --global
+```
+
+Your projects are unaffected — `.ymir/` specs and generated harnesses are written
+into each repo and do not depend on how Ymir itself was installed.
 
 **Telemetry:** the skills CLI collects anonymous usage telemetry.
 Set `DISABLE_TELEMETRY=1` or `DO_NOT_TRACK=1` to opt out.
@@ -126,8 +159,11 @@ not merely withheld. Forks and internal deployments can redirect reports with
 
 ## Status
 
-`v0.6.0`. Ymir runs a codebase-first flow: it scans the repo, then runs a deep
-per-concern Socratic interview (probe *why* → recommend → confirm, capturing
+The current version is the release badge above — it is generated, so it cannot go
+stale the way a number written here does.
+
+Ymir runs a codebase-first flow: it scans the repo, then runs a deep per-concern
+Socratic interview (probe *why* → recommend → confirm, capturing
 `why`/`findings`), a consistency + reflection gate, a spec-review gate, and a spec
 emitted to `.ymir/` (`harness-profile.yaml` + `harness-playbook.md`); `ymir apply`
 then generates the harness from that spec (with backups + `ymir revert`). The
@@ -135,7 +171,7 @@ spec's per-concern playbook sections live in `plugins/ymir/templates/playbook/`;
 the interview engine is in `plugins/ymir/references/socratic-interview.md`. The
 **rules** concern emits native `.claude/rules/*.md` for Claude Code targets, or
 embeds rules inline in `AGENT.md` for agent-neutral harnesses. The **wiki / context**
-section drives the bundled wiki tooling (`plugins/ymir/wiki-cli`, templates, and
-the PreToolUse hook for Claude Code or a CI gate for other agents). The harness
-profile records `target_agent` (claude-code or any) so every concern generates
-the right output for the chosen agent.
+section drives the bundled wiki tooling (source in `wiki-cli/`, shipped as a
+release binary), the templates, and the PreToolUse hook for Claude Code or a CI
+gate for other agents. The harness profile records `target_agent` (claude-code or
+any) so every concern generates the right output for the chosen agent.

--- a/plugins/ymir/SKILL.md
+++ b/plugins/ymir/SKILL.md
@@ -58,9 +58,9 @@ entry, the `CLAUDE.md` block, and the validation step.
 
 All asset paths below (`references/`, `templates/`, `wiki-cli/`, `hooks/`) are
 **relative to this skill's root directory** — the directory that contains this
-`SKILL.md`. Resolve `$SKILL_ROOT` as that directory before running any command
-(`CLAUDE_PLUGIN_ROOT` holds it in Claude Code plugin installs; derive it from this
-file's path for skills-CLI installs).
+`SKILL.md`. Derive `$SKILL_ROOT` from this file's own path before running any
+command; it is wherever the skills CLI installed Ymir (commonly
+`~/.claude/skills/ymir/` or a project-local `.claude/skills/ymir/`).
 
 Provision the wiki binary once (idempotent), then scaffold from the project root:
 

--- a/plugins/ymir/hooks/ensure-wiki-binary.mjs
+++ b/plugins/ymir/hooks/ensure-wiki-binary.mjs
@@ -95,8 +95,14 @@ const sumsUrl  = `${base}/SHA256SUMS.txt`;
 
 mkdirSync(binDir, { recursive: true });
 
-const tmpBin  = `${binPath}.tmp`;
-const tmpSums = join(binDir, "SHA256SUMS.txt.tmp");
+// Scratch paths are per-process because more than one run can be in flight at
+// once — Claude Code fires this at session start, and installing the skill can
+// trigger it again while the first download is still going. Sharing one
+// `wiki.tmp` let two curls interleave into the same file, which either corrupts
+// the binary past the sha256 gate or makes one run delete the other's work
+// mid-flight. The final rename is atomic, so the last verified writer wins.
+const tmpBin  = `${binPath}.${process.pid}.tmp`;
+const tmpSums = join(binDir, `SHA256SUMS.txt.${process.pid}.tmp`);
 
 const cleanupTmp = () => {
   try { unlinkSync(tmpBin); } catch {}

--- a/wiki-cli/bunfig.toml
+++ b/wiki-cli/bunfig.toml
@@ -1,0 +1,5 @@
+[test]
+# Several suites spawn the real CLI or the install hook, so each case pays full
+# process startup. The 5s default is marginal once those files run concurrently,
+# which surfaced as a flake rather than an honest failure.
+timeout = 30000

--- a/wiki-cli/test/ensure-binary-race.test.ts
+++ b/wiki-cli/test/ensure-binary-race.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, readdirSync, chmodSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+
+const HOOK = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..", "..", "plugins", "ymir", "hooks", "ensure-wiki-binary.mjs",
+);
+
+let skillRoot: string;
+let home: string;
+let stubDir: string;
+let ledger: string;
+
+beforeEach(() => {
+  skillRoot = mkdtempSync(join(tmpdir(), "race-skill-"));
+  home = mkdtempSync(join(tmpdir(), "race-home-"));
+  stubDir = mkdtempSync(join(tmpdir(), "race-bin-"));
+  ledger = join(stubDir, "ledger.txt");
+
+  mkdirSync(join(skillRoot, ".claude-plugin"), { recursive: true });
+  writeFileSync(join(skillRoot, ".claude-plugin", "plugin.json"), JSON.stringify({ version: "9.9.9" }));
+
+  // Stand in for curl: record the --output path this process was told to use,
+  // then fail so the hook bails without touching the network.
+  writeFileSync(
+    join(stubDir, "curl"),
+    `#!/bin/sh
+while [ $# -gt 0 ]; do
+  if [ "$1" = "--output" ]; then shift; echo "$1" >> "${ledger}"; fi
+  shift
+done
+exit 1
+`,
+  );
+  chmodSync(join(stubDir, "curl"), 0o755);
+});
+
+function runHook(): Promise<number> {
+  return new Promise((resolve) => {
+    const child = spawn("node", [HOOK], {
+      stdio: "ignore",
+      env: {
+        ...process.env,
+        CLAUDE_PLUGIN_ROOT: skillRoot,
+        YMIR_HOME: home,
+        PATH: `${stubDir}:${process.env.PATH}`,
+      },
+    });
+    child.on("exit", (code) => resolve(code ?? -1));
+  });
+}
+
+function recordedOutputPaths(): string[] {
+  if (!existsSync(ledger)) return [];
+  return readFileSync(ledger, "utf8").split("\n").filter((l) => l.trim() !== "");
+}
+
+describe("ensure-wiki-binary concurrency", () => {
+  it("gives each concurrent run its own download target", async () => {
+    const codes = await Promise.all([runHook(), runHook()]);
+    expect(codes).toEqual([2, 2]);
+
+    const paths = recordedOutputPaths();
+    expect(paths).toHaveLength(2);
+    expect(new Set(paths).size).toBe(2);
+  });
+
+  it("leaves no temp debris behind", async () => {
+    await Promise.all([runHook(), runHook(), runHook()]);
+
+    const binDir = join(skillRoot, "wiki-cli", "bin");
+    const leftovers = existsSync(binDir) ? readdirSync(binDir).filter((f) => f.includes(".tmp")) : [];
+    expect(leftovers).toEqual([]);
+  });
+
+  it("scopes the temp name to the running process", async () => {
+    await runHook();
+    const [path] = recordedOutputPaths();
+    expect(path).toMatch(/\.\d+\.tmp$/);
+  });
+});

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -75,3 +75,5 @@
 ## [2026-08-21] ingest | Ymir README
 ## [2026-08-21] ingest | Ymir SKILL Dispatcher
 ## [2026-08-21] note | Wiki CLI Command Surface
+## [2026-08-21] ingest | Ymir README
+## [2026-08-21] ingest | Ymir SKILL Dispatcher

--- a/wiki/sources/ymir-readme.md
+++ b/wiki/sources/ymir-readme.md
@@ -5,36 +5,48 @@ date: 2026-08-21
 tags: []
 source: README.md
 source_path: README.md
-source_hash: 1e42ea494c67cb9c1e84ba990a19b2d872591fd676802118a135457821cda03d
+source_hash: e17664f73bcd594c924192ebb0e77c317a6fa98c66a8bd7eaf7ebfcc487e1dd7
 ingested: 2026-08-21
 ---
 
 # Ymir README
 
-Ymir is a Claude Code plugin and agent skill that produces a harness spec for a
-repo — rules, lint, CI lint, wiki/context, and `CLAUDE.md`/`AGENT.md`. It never
-generates application code. It explores the codebase, runs a deep per-concern
-Socratic interview, re-audits for consistency, and emits
-`.ymir/harness-profile.yaml` plus `.ymir/harness-playbook.md`; `ymir apply` then
-generates the harness with backups, and `ymir revert` undoes the last apply.
+Ymir is an agent skill that produces a harness spec for a repo — rules, lint, CI
+lint, wiki/context, and `CLAUDE.md`/`AGENT.md`. It never generates application
+code. It explores the codebase, runs a deep per-concern Socratic interview,
+re-audits for consistency, and emits `.ymir/harness-profile.yaml` plus
+`.ymir/harness-playbook.md`; `ymir apply` then generates the harness with backups,
+and `ymir revert` undoes the last apply.
 
-Install either as a Claude Code plugin, which wires the hooks automatically, or
-as an agent skill via the skills CLI, which reaches Cursor and Codex too but
-needs the wiki binary bootstrapped once by hand.
+Distribution is through the skills CLI only: `npx skills@latest add
+muitneliss/ymir`, with `--global` to install for every project. It works with
+Claude Code, Cursor, Codex and any other agent the skills CLI supports, landing
+in `~/.claude/skills/ymir/` or the agent-specific equivalent. Distribution is
+purely git — `skills add` clones straight from the repo, so there is no publish
+step or registry account — and `skills update` / `skills remove` manage the
+lifecycle. The earlier Claude Code plugin and marketplace path is retired; the
+README keeps a short migration recipe (`claude plugin uninstall`, `marketplace
+remove`, then `skills add`), noting that projects are unaffected because `.ymir/`
+specs and generated harnesses live in each repo rather than in the install.
 
-The README documents the self-report contract. Because Ymir runs on the user's
-own machine, its failures are invisible upstream unless sent. A crash writes a
-redacted report to `~/.ymir/` and says so; nothing is transmitted until the user
-runs `wiki report --yes`, and `wiki report` alone prints the literal issue body
-for review. Reports carry the subcommand, error type and message, Ymir's version
-and the OS and architecture — paths, hostnames, email addresses, git remotes and
-credential-shaped strings are stripped before anything is stored, project paths
-keep only their relative tail, and no file contents or argument values are ever
-included. Delivery uses the user's own `gh` login, so the issue is filed by them
-and Ymir ships no credential; without `gh` a prefilled issue URL is printed
-instead. Opting out via `wiki report --off`, `DO_NOT_TRACK=1`,
-`DISABLE_TELEMETRY=1` or `YMIR_REPORT=off` stops capture entirely rather than
-merely withholding, and forks can redirect reports with `YMIR_REPORT_REPO`.
+The `wiki` CLI is a compiled binary fetched from GitHub Releases on first use,
+matched to the installed version and verified against a published SHA256. Claude
+Code fetches it automatically at session start; other agents run
+`ensure-wiki-binary.mjs` once, then scaffold with `wiki init --no-hook`.
+
+The README also documents the self-report contract. A crash writes a redacted
+report to `~/.ymir/` and says so; nothing is transmitted until the user runs
+`wiki report --yes`, and `wiki report` alone prints the literal issue body for
+review. Reports carry the subcommand, error, version and OS/arch only — paths,
+hostnames, emails, git remotes and credential-shaped strings are stripped before
+storage, and no file contents or argument values are included. Delivery uses the
+user's own `gh` login so no credential ships; without `gh` a prefilled issue URL
+is printed. Opting out via `--off`, `DO_NOT_TRACK=1`, `DISABLE_TELEMETRY=1` or
+`YMIR_REPORT=off` stops capture entirely, and forks redirect with
+`YMIR_REPORT_REPO`.
+
+The Status section points at the generated release badge rather than a
+hand-written version number, which had drifted two releases behind.
 
 See [[Ymir SKILL Dispatcher]] for the skill flow, [[Ymir Self-Report Design]] for
 the reporting architecture, and [[Wiki Schema]] for the wiki CLI rules.

--- a/wiki/sources/ymir-skill-dispatcher.md
+++ b/wiki/sources/ymir-skill-dispatcher.md
@@ -5,7 +5,7 @@ date: 2026-08-21
 tags: []
 source: plugins/ymir/SKILL.md
 source_path: plugins/ymir/SKILL.md
-source_hash: f9b11b2bf987886213aa575a410f25864de9694ee7c97c6977961e25fbef3cea
+source_hash: 3bd4ebf7b43a6ba605c0eb749fd9499305246f01ecadb6b2d9c482804de4478b
 ingested: 2026-08-21
 ---
 
@@ -29,6 +29,11 @@ a summary. `ymir revert` restores that run's backups, with the documented
 limitation that files created from scratch have no backup. The wiki-only intents
 `ymir add context` and `ymir add wiki` are the one exception that writes project
 files directly, via a single CLI call.
+
+Asset paths are resolved relative to `$SKILL_ROOT`, the directory containing
+`SKILL.md`, derived from the file's own path — commonly `~/.claude/skills/ymir/`
+or a project-local `.claude/skills/ymir/` now that distribution is the skills CLI
+rather than a Claude Code plugin.
 
 The skill also carries the self-report protocol. The wiki CLI captures its own
 crashes unaided; what it cannot see is this skill's flow breaking — a playbook


### PR DESCRIPTION
Two changes, both found while migrating a real machine off the Claude Code plugin onto `npx skills`.

## 1. Docs: the skills CLI is now the only documented install path

The plugin/marketplace path is retired from the README. The skills CLI already covers Claude Code alongside Cursor and Codex, so this is one install path to document and support instead of two.

- `npx skills@latest add muitneliss/ymir` (with `--global`) is the install; `skills update` / `skills remove` are the lifecycle.
- Added a **migration recipe** so existing plugin users aren't stranded, and noted their projects are unaffected — `.ymir/` specs and generated harnesses live in each repo, not in the install.
- Clarified the wiki binary story: fetched from Releases, sha256-verified, automatic under Claude Code, one manual command elsewhere.
- `SKILL.md` no longer tells the agent to look for `CLAUDE_PLUGIN_ROOT`.
- Corrected the Layout tree (`wiki-cli/` moved to the repo root in 0.7.0 and is not part of the payload).

`.claude-plugin/marketplace.json` **stays in the repo** — release-please's `extra-files` propagates the version into it, and un-migrated users still resolve through it. Only the docs change.

Also replaced the hand-written `v0.6.0` in Status with the generated release badge; it had silently drifted two releases behind, which is exactly what a hardcoded version does.

## 2. Fix: concurrent binary installs raced on shared temp files

Observed for real during the migration — **two `curl` processes writing the same `wiki.tmp` simultaneously**:

```
65365 curl -fsSL --output .../wiki-cli/bin/wiki.tmp .../wiki-darwin-arm64
65494 curl -fsSL --output .../wiki-cli/bin/wiki.tmp .../wiki-darwin-arm64
```

Claude Code fires `ensure-wiki-binary` at session start, and installing the skill can trigger it again while the first download is still running. Both runs used fixed `wiki.tmp` / `SHA256SUMS.txt.tmp` paths, so two curls could interleave into one file — corrupting the binary past the sha256 gate, or one run deleting the other's work mid-flight. It left a stray `SHA256SUMS.txt.tmp` behind.

That binary happened to verify clean (checked against the published SHA256), but that was luck. And it matters more now: a failed checksum would file a spurious `ChecksumMismatch` self-report.

Scratch paths are now per-process; the final `rename` was already atomic, so the last verified writer wins.

**Test reproduces the bug** (`test/ensure-binary-race.test.ts`): a stub `curl` records the `--output` path it was handed, two hooks run concurrently, and the test asserts the two paths differ. It fails on the old code with `Set(paths).size === 1`, and needs no network.

## Verification

403 tests, 0 fail. Payload still 13 files (CI limit 20), no `${CLAUDE_PLUGIN_ROOT}` in skill content, `wiki check` passes, README/SKILL.md re-ingested into the wiki.

Also raised the bun test timeout to 30s via `bunfig.toml` — suites that spawn the real CLI were marginal against the 5s default once the new race test added process contention, which showed up as a flake rather than an honest failure.